### PR TITLE
Update for precision_n_scores docstring

### DIFF
--- a/pyod/utils/utility.py
+++ b/pyod/utils/utility.py
@@ -143,7 +143,7 @@ def precision_n_scores(y, y_pred, n=None):
     Utility function to calculate precision@ rank
 
     :param y: ground truth
-    :param y_pred: number of outliers
+    :param y_pred: predicted outlier scores as returned by fitted model (not rounded off)
     :param n: number of outliers, if not defined, infer using ground truth
     :return: precision at rank n score
     :rtype: float


### PR DESCRIPTION
This was a little confusing for me working with this library, took me a while to figure out the function required raw scores instead of rounded ones (in which case it throws a precision being ill-defined error due to no predicted samples).