### PR TITLE
Building query tree can be skipped

### DIFF
--- a/pyod/models/knn.py
+++ b/pyod/models/knn.py
@@ -170,13 +170,6 @@ class KNN(BaseDetector):
         X = check_array(X)
         self._set_n_classes(y)
 
-        if self.metric_params is not None:
-            self.tree_ = BallTree(X, leaf_size=self.leaf_size,
-                                  metric=self.metric,
-                                  **self.metric_params)
-        else:
-            self.tree_ = BallTree(X, leaf_size=self.leaf_size,
-                                  metric=self.metric)
         self.neigh_.fit(X)
         if self.neigh_._tree is not None:
             self.tree_ = self.neigh_._tree

--- a/pyod/models/knn.py
+++ b/pyod/models/knn.py
@@ -178,6 +178,16 @@ class KNN(BaseDetector):
             self.tree_ = BallTree(X, leaf_size=self.leaf_size,
                                   metric=self.metric)
         self.neigh_.fit(X)
+        if self.neigh_._tree is not None:
+            self.tree_ = self.neigh_._tree
+        else:
+            if self.metric_params is not None:
+                self.tree_ = BallTree(X, leaf_size=self.leaf_size,
+                                    metric=self.metric,
+                                    **self.metric_params)
+            else:
+                self.tree_ = BallTree(X, leaf_size=self.leaf_size,
+                                  metric=self.metric)
 
         dist_arr, _ = self.neigh_.kneighbors(n_neighbors=self.n_neighbors,
                                              return_distance=True)


### PR DESCRIPTION
Building query tree is available inside sklearn.NearestNeighbor._tree. Therefore, no need to rebuild.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.


