### PR TITLE
Switch from (pure) keras based on tensorflow to the keras loaded from the tensorflow library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,11 +207,9 @@ be found at `Moving to require Python 3 <https://python3statement.org/>`_.
 
 **Optional Dependencies (see details below)**\ :
 
-
-* keras (optional, required for AutoEncoder)
 * matplotlib (optional, required for running examples)
 * pandas (optional, required for running benchmark)
-* tensorflow (optional, required for AutoEncoder, other backend works)
+* tensorflow (optional, required for AutoEncoder)
 * xgboost (optional, required for XGBOD)
 
 **Warning 1**\ :

--- a/pyod/models/auto_encoder.py
+++ b/pyod/models/auto_encoder.py
@@ -37,19 +37,19 @@ class AutoEncoder(BaseDetector):
     hidden_activation : str, optional (default='relu')
         Activation function to use for hidden layers.
         All hidden layers are forced to use the same type of activation.
-        See https://keras.io/activations/
+        See https://www.tensorflow.org/api_docs/python/tf/keras/activations/ 
 
     output_activation : str, optional (default='sigmoid')
         Activation function to use for output layer.
-        See https://keras.io/activations/
+        See https://www.tensorflow.org/api_docs/python/tf/keras/activations/
 
-    loss : str or obj, optional (default=keras.losses.mean_squared_error)
+    loss : str or obj, optional (default=tensorflow.keras.losses.MSE)
         String (name of objective function) or objective function.
-        See https://keras.io/losses/
+        See https://www.tensorflow.org/api_docs/python/tf/keras/losses/ 
 
     optimizer : str, optional (default='adam')
         String (name of optimizer) or optimizer instance.
-        See https://keras.io/optimizers/
+        See hhttps://www.tensorflow.org/api_docs/python/tf/keras/optimizers/
 
     epochs : int, optional (default=100)
         Number of epochs to train the model.
@@ -63,7 +63,7 @@ class AutoEncoder(BaseDetector):
     l2_regularizer : float in (0., 1), optional (default=0.1)
         The regularization strength of activity_regularizer
         applied on each layer. By default, l2 regularizer is used. See
-        https://keras.io/regularizers/
+        https://www.tensorflow.org/api_docs/python/tf/keras/regularizers/
 
     validation_size : float in (0., 1), optional (default=0.1)
         The percentage of data to be used for validation.

--- a/pyod/models/auto_encoder.py
+++ b/pyod/models/auto_encoder.py
@@ -8,10 +8,10 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from keras.models import Sequential
-from keras.layers import Dense, Dropout
-from keras.regularizers import l2
-from keras.losses import mean_squared_error
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Dropout
+from tensorflow.keras.regularizers import l2
+from tensorflow.keras.losses import mean_squared_error
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted

--- a/pyod/models/gaal_base.py
+++ b/pyod/models/gaal_base.py
@@ -10,9 +10,9 @@ from __future__ import print_function
 
 import math
 
-import keras
-from keras.layers import Input, Dense
-from keras.models import Sequential, Model
+import tensorflow
+from tensorflow.keras.layers import Input, Dense
+from tensorflow.keras.models import Sequential, Model
 
 
 # TODO: create a base class for so_gaal and mo_gaal
@@ -36,11 +36,11 @@ def create_discriminator(latent_size, data_size):  # pragma: no cover
     dis = Sequential()
     dis.add(Dense(int(math.ceil(math.sqrt(data_size))),
                   input_dim=latent_size, activation='relu',
-                  kernel_initializer=keras.initializers.VarianceScaling(
+                  kernel_initializer=tensorflow.keras.initializers.VarianceScaling(
                       scale=1.0, mode='fan_in', distribution='normal',
                       seed=None)))
     dis.add(Dense(1, activation='sigmoid',
-                  kernel_initializer=keras.initializers.VarianceScaling(
+                  kernel_initializer=tensorflow.keras.initializers.VarianceScaling(
                       scale=1.0, mode='fan_in', distribution='normal',
                       seed=None)))
     data = Input(shape=(latent_size,))
@@ -64,10 +64,10 @@ def create_generator(latent_size):  # pragma: no cover
 
     gen = Sequential()
     gen.add(Dense(latent_size, input_dim=latent_size, activation='relu',
-                  kernel_initializer=keras.initializers.Identity(
+                  kernel_initializer=tensorflow.keras.initializers.Identity(
                       gain=1.0)))
     gen.add(Dense(latent_size, activation='relu',
-                  kernel_initializer=keras.initializers.Identity(
+                  kernel_initializer=tensorflow.keras.initializers.Identity(
                       gain=1.0)))
     latent = Input(shape=(latent_size,))
     fake_data = gen(latent)

--- a/pyod/models/mo_gaal.py
+++ b/pyod/models/mo_gaal.py
@@ -12,9 +12,9 @@ from collections import defaultdict
 
 import numpy as np
 
-from keras.layers import Input
-from keras.models import Model
-from keras.optimizers import SGD
+from tensorflow.keras.layers import Input
+from tensorflow.keras.models import Model
+from tensorflow.keras.optimizers import SGD
 
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted

--- a/pyod/models/so_gaal.py
+++ b/pyod/models/so_gaal.py
@@ -12,9 +12,9 @@ from collections import defaultdict
 
 import numpy as np
 
-from keras.layers import Input
-from keras.models import Model
-from keras.optimizers import SGD
+from tensorflow.keras.layers import Input
+from tensorflow.keras.models import Model
+from tensorflow.keras.optimizers import SGD
 
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted


### PR DESCRIPTION
### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

According to the https://keras.io/ I think, that that's good idea to switch from pure keras to keras loaded from tensorflow:

### Multi-backend Keras and tf.keras:
At this time, we recommend that Keras users who use multi-backend Keras with the TensorFlow backend switch to tf.keras in TensorFlow 2.0. tf.keras is better maintained and has better integration with TensorFlow features (eager execution, distribution support and other).

Keras 2.2.5 was the last release of Keras implementing the 2.2.* API. It was the last release to only support TensorFlow 1 (as well as Theano and CNTK).

The current release is Keras 2.3.0, which makes significant API changes and add support for TensorFlow 2.0. The 2.3.0 release will be the last major release of multi-backend Keras. Multi-backend Keras is superseded by tf.keras.

Bugs present in multi-backend Keras will only be fixed until April 2020 (as part of minor releases).

For more information about the future of Keras, see the Keras meeting notes
