### PR TITLE
fixed SOD bug due to a typo

### DIFF
--- a/pyod/models/sod.py
+++ b/pyod/models/sod.py
@@ -28,7 +28,7 @@ def _snn_imp(ind, ref_set_):
 
     """
     n = ind.shape[0]
-    _count = np.zeros(shape=(n, ref_set_), dtype=nb.uint16)
+    _count = np.zeros(shape=(n, ref_set_), dtype=nb.uint32)
     for i in nb.prange(n):
         temp = np.empty(n, dtype=nb.int16)
         test_element_set = set(ind[i])


### PR DESCRIPTION
I found  a bug in SOD, the data type of one of the lists was set to int16 causing overflow for large datasets. Changing it into int32 fixed the problem fully.

Please merge into master as soon as possible to avoid any confusion to the users because the bug was hidden and not throwing any error. 