### PR TITLE
changed random state definition as a temp fix... issue stemming from …

### DIFF
--- a/examples/compare_all_models.py
+++ b/examples/compare_all_models.py
@@ -71,7 +71,7 @@ print(
         shape=ground_truth.shape))
 print(ground_truth, '\n')
 
-random_state = np.random.RandomState(42)
+random_state = 42
 # Define nine outlier detection tools to be compared
 classifiers = {
     'Angle-based Outlier Detector (ABOD)':


### PR DESCRIPTION
As per our discussion, minor fix which resolves failure of running compare_all_models.py

The true issue seems to be in [utility.py](https://github.com/yzhao062/pyod/blob/a63e8678e3ce2ab27916432e465fcd42a4e3e4bf/pyod/utils/utility.py#L446), where the sample_without_replacement function (called in generate_indices) produces inconsistent results with np.random.RandomState(42). Take a deeper look at this interaction to solve permanently. 

