### PR TITLE
Parallelize the fit and decision_function methods of FeatureBagging

### DIFF
--- a/pyod/models/feature_bagging.py
+++ b/pyod/models/feature_bagging.py
@@ -308,7 +308,6 @@ class FeatureBagging(BaseDetector):
 
         return self
 
-
     def decision_function(self, X):
         """Predict raw anomaly score of X using the fitted detector.
         The anomaly score of an input sample is computed based on different

--- a/pyod/models/feature_bagging.py
+++ b/pyod/models/feature_bagging.py
@@ -8,9 +8,8 @@ from __future__ import print_function
 
 import numpy as np
 import numbers
-
-from joblib import Parallel
-from joblib.parallel import delayed
+import itertools
+from joblib import delayed, Parallel
 
 from sklearn.base import clone
 from sklearn.utils import check_random_state
@@ -69,23 +68,45 @@ def _set_random_states(estimator, random_state=None):
         estimator.set_params(**to_set)
 
 
-# def _parallel_decision_function(estimators, estimators_features, X):
-#     n_samples = X.shape[0]
-#     scores = np.zeros((n_samples, len(estimators)))
-#
-#     for i, (estimator, features) in enumerate(
-#             zip(estimators, estimators_features)):
-#         if hasattr(estimator, 'decision_function'):
-#             estimator_score = estimator.decision_function(
-#                 X[:, features])
-#             scores[:, i] = estimator_score
-#         else:
-#             raise NotImplementedError(
-#                 'current base detector has no decision_function')
-#     return scores
+def _parallel_decision_function(estimators, estimators_features, X):
+    n_samples = X.shape[0]
+    scores = np.zeros((n_samples, len(estimators)))
 
+    for i, (estimator, features) in enumerate(
+            zip(estimators, estimators_features)):
+        if hasattr(estimator, 'decision_function'):
+            estimator_score = estimator.decision_function(
+                X[:, features])
+            scores[:, i] = estimator_score
+        else:
+            raise NotImplementedError(
+                'current base detector has no decision_function')
+    return scores
 
-# TODO: should support parallelization at the model level
+def _parallel_fit_estimators(n_estimators,ensemble,X,seeds):
+    estimators = []
+    estimators_features = []
+
+    for i in range(n_estimators):
+        random_state = np.random.RandomState(seeds[i])
+
+        # max_features is incremented by one since random
+        # function is [min_features, max_features)
+        features = generate_bagging_indices(random_state,
+                                            ensemble.bootstrap_features,
+                                            ensemble.n_features_,
+                                            ensemble.min_features_,
+                                            ensemble.max_features_ + 1)
+        # initialize and append estimators
+        estimator = ensemble._make_estimator(append=False,
+                                            random_state=random_state)
+        estimator.fit(X[:, features])
+        
+        estimators.append(estimator)
+        estimators_features.append(features)
+
+    return estimators, estimators_features
+
 # TODO: detector score combination through BFS should be implemented
 # See https://github.com/yzhao062/pyod/issues/59
 class FeatureBagging(BaseDetector):
@@ -209,7 +230,7 @@ class FeatureBagging(BaseDetector):
             self.estimator_params = estimator_params
         else:
             self.estimator_params = {}
-
+    
     def fit(self, X, y=None):
         """Fit detector. y is ignored in unsupervised methods.
 
@@ -255,36 +276,26 @@ class FeatureBagging(BaseDetector):
                         param_name='max_features', high=self.n_features_,
                         include_left=True, include_right=True)
 
-        self.estimators_ = []
-        self.estimators_features_ = []
-
-        n_more_estimators = self.n_estimators - len(self.estimators_)
-
-        if n_more_estimators < 0:
-            raise ValueError('n_estimators=%d must be larger or equal to '
-                             'len(estimators_)=%d when warm_start==True'
-                             % (self.n_estimators, len(self.estimators_)))
-
-        seeds = random_state.randint(MAX_INT, size=n_more_estimators)
+        seeds = random_state.randint(MAX_INT, size=self.n_estimators)
         self._seeds = seeds
 
-        for i in range(self.n_estimators):
-            random_state = np.random.RandomState(seeds[i])
+        n_jobs, n_estimators, starts = _partition_estimators(self.n_estimators,
+                                                             self.n_jobs)
 
-            # max_features is incremented by one since random
-            # function is [min_features, max_features)
-            features = generate_bagging_indices(random_state,
-                                                self.bootstrap_features,
-                                                self.n_features_,
-                                                self.min_features_,
-                                                self.max_features_ + 1)
-            # initialize and append estimators
-            estimator = self._make_estimator(append=False,
-                                             random_state=random_state)
-            estimator.fit(X[:, features])
+        all_results = Parallel(n_jobs=self.n_jobs,verbose=self.verbose)(
+            delayed(_parallel_fit_estimators)(
+                n_estimators[i],
+                self,
+                X,
+                seeds[starts[i]:starts[i + 1]])
+            for i in range(n_jobs))
 
-            self.estimators_.append(estimator)
-            self.estimators_features_.append(features)
+        self.estimators_ = list(itertools.chain.from_iterable(
+            t[0] for t in all_results))
+
+        self.estimators_features_ = list(itertools.chain.from_iterable(
+            t[1] for t in all_results))
+
 
         # decision score matrix from all estimators
         all_decision_scores = self._get_decision_scores()
@@ -298,9 +309,8 @@ class FeatureBagging(BaseDetector):
 
         return self
 
-    def decision_function(self, X):
+def decision_function(self, X):
         """Predict raw anomaly score of X using the fitted detector.
-
         The anomaly score of an input sample is computed based on different
         detector algorithms. For consistency, outliers are assigned with
         larger anomaly scores.
@@ -326,32 +336,22 @@ class FeatureBagging(BaseDetector):
                              "input n_features is {1}."
                              "".format(self.n_features_, X.shape[1]))
 
-        # Parallel loop
-        # n_jobs, n_estimators, starts = _partition_estimators(self.n_estimators,
-        #                                                      self.n_jobs)
-        # all_pred_scores = Parallel(n_jobs=n_jobs, verbose=self.verbose)(
-        #     delayed(_parallel_decision_function)(
-        #         self.estimators_[starts[i]:starts[i + 1]],
-        #         self.estimators_features_[starts[i]:starts[i + 1]],
-        #         X)
-        #     for i in range(n_jobs))
-        #
-        # # Reduce
-        # all_pred_scores = np.concatenate(all_pred_scores, axis=1)
-        all_pred_scores = self._predict_decision_scores(X)
-
+        n_jobs, n_estimators, starts = _partition_estimators(self.n_estimators,
+                                                             self.n_jobs)
+        all_pred_scores = Parallel(n_jobs=n_jobs, verbose=self.verbose)(
+            delayed(_parallel_decision_function)(
+                self.estimators_[starts[i]:starts[i + 1]],
+                self.estimators_features_[starts[i]:starts[i + 1]],
+                X)
+            for i in range(n_jobs))
+        
+        # Reduce
+        all_pred_scores = np.concatenate(all_pred_scores, axis=1)
+        
         if self.combination == 'average':
             return average(all_pred_scores)
         else:
             return maximization(all_pred_scores)
-
-    def _predict_decision_scores(self, X):
-        all_pred_scores = np.zeros([X.shape[0], self.n_estimators])
-        for i in range(self.n_estimators):
-            features = self.estimators_features_[i]
-            all_pred_scores[:, i] = self.estimators_[i].decision_function(
-                X[:, features])
-        return all_pred_scores
 
     def _get_decision_scores(self):
         all_decision_scores = np.zeros([self.n_samples_, self.n_estimators])

--- a/pyod/test/test_feature_bagging.py
+++ b/pyod/test/test_feature_bagging.py
@@ -3,7 +3,7 @@
 from __future__ import division
 from __future__ import print_function
 
-import os
+mport os
 import sys
 
 import unittest
@@ -127,8 +127,9 @@ class TestFeatureBagging(unittest.TestCase):
         assert_array_less(-0.1, pred_ranks)
 
     def test_parallel(self):
-        feat_bag = FeatureBagging(n_jobs=3,
-                               random_state=42).fit(self.X_train, self.y_train)
+        feat_bag = FeatureBagging(
+                            n_jobs=3,
+                            random_state=42).fit(self.X_train, self.y_train)
 
         # predict_proba
         feat_bag.set_params(n_jobs=1)
@@ -137,15 +138,17 @@ class TestFeatureBagging(unittest.TestCase):
         y2 = feat_bag.predict_proba(self.X_test)
         assert_array_almost_equal(y1, y2)
 
-        feat_bag = FeatureBagging(n_jobs=1,
-                               random_state=42).fit(self.X_train, self.y_train)
+        feat_bag = FeatureBagging(
+                            n_jobs=1,
+                            random_state=42).fit(self.X_train, self.y_train)
 
         y3 = feat_bag.predict_proba(self.X_test)
         assert_array_almost_equal(y1, y3)
 
         # decision_function
-        feat_bag = FeatureBagging(n_jobs=3,
-                               random_state=42).fit(self.X_train, self.y_train)
+        feat_bag = FeatureBagging(
+                            n_jobs=3,
+                            random_state=42).fit(self.X_train, self.y_train)
 
         feat_bag.set_params(n_jobs=1)
         decisions1 = feat_bag.decision_function(self.X_test)
@@ -153,8 +156,9 @@ class TestFeatureBagging(unittest.TestCase):
         decisions2 = feat_bag.decision_function(self.X_test)
         assert_array_almost_equal(decisions1, decisions2)
 
-        feat_bag = FeatureBagging(n_jobs=1,
-                               random_state=42).fit(self.X_train, self.y_train)
+        feat_bag = FeatureBagging(
+                            n_jobs=1,
+                            random_state=42).fit(self.X_train, self.y_train)
 
         decisions3 = feat_bag.decision_function(self.X_test)
         assert_array_almost_equal(decisions1, decisions3)

--- a/pyod/test/test_feature_bagging.py
+++ b/pyod/test/test_feature_bagging.py
@@ -3,7 +3,7 @@
 from __future__ import division
 from __future__ import print_function
 
-mport os
+import os
 import sys
 
 import unittest

--- a/pyod/test/test_feature_bagging.py
+++ b/pyod/test/test_feature_bagging.py
@@ -15,6 +15,7 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_greater_equal
 from sklearn.utils.testing import assert_less_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_array_almost_equal
 
 from sklearn.utils.estimator_checks import check_estimator
 
@@ -124,6 +125,39 @@ class TestFeatureBagging(unittest.TestCase):
         assert_allclose(rankdata(pred_ranks), rankdata(pred_socres), atol=3)
         assert_array_less(pred_ranks, 1.01)
         assert_array_less(-0.1, pred_ranks)
+
+    def test_parallel(self):
+        feat_bag = FeatureBagging(n_jobs=3,
+                               random_state=42).fit(self.X_train, self.y_train)
+
+        # predict_proba
+        feat_bag.set_params(n_jobs=1)
+        y1 = feat_bag.predict_proba(self.X_test)
+        feat_bag.set_params(n_jobs=2)
+        y2 = feat_bag.predict_proba(self.X_test)
+        assert_array_almost_equal(y1, y2)
+
+        feat_bag = FeatureBagging(n_jobs=1,
+                               random_state=42).fit(self.X_train, self.y_train)
+
+        y3 = feat_bag.predict_proba(self.X_test)
+        assert_array_almost_equal(y1, y3)
+
+        # decision_function
+        feat_bag = FeatureBagging(n_jobs=3,
+                               random_state=42).fit(self.X_train, self.y_train)
+
+        feat_bag.set_params(n_jobs=1)
+        decisions1 = feat_bag.decision_function(self.X_test)
+        feat_bag.set_params(n_jobs=2)
+        decisions2 = feat_bag.decision_function(self.X_test)
+        assert_array_almost_equal(decisions1, decisions2)
+
+        feat_bag = FeatureBagging(n_jobs=1,
+                               random_state=42).fit(self.X_train, self.y_train)
+
+        decisions3 = feat_bag.decision_function(self.X_test)
+        assert_array_almost_equal(decisions1, decisions3)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
This PR Parallelize the `fit` and `decision_function` methods of `FeatureBagging`. The earlier implementation only used the `n_jobs`  when `base_estimator` parameter is None. Apart from fixing that, the model level PR enables parallelism at more coarser level, thereby noticeably improving performance. 

Benchmark results using `n_estimators=20` and `base_estimator=None`, averaged over 3 runs. Values indicate `fit` time in seconds, the one inside bracket denote time for `decision_function`: 
|Dataset (shape) | Orig (n_jobs=1) |Orig (n_jobs=4) | This PR (n_jobs=4) |
| --------| ------------------| -----------------| --------------------|
|pima (768, 8)    | 0.19 (0.094)       | 2.30 (2.155)        | 0.64 (0.63)            |
|vowels (1456, 12) | 0.71 (0.42)         | 2.36 (2.17)          | 0.66 (0.64)            |
|pendigits (6870, 16)| 9.12 (5.02)      | 5.87 (4.32)          | 1.78 (1.42)            |
|musk (3062, 166)| 18.92 (8.32)          | 7.46 (5.88)           |  3.90 (2.79)    |
| shuttle (49097, 9)| 59.09 (38.67)    | 46.10 (28.11)       | 33.43 (18.01)    |

Performance can be slightly worse than single-process method for smaller datasets, but I think that is expected.

Please let me know if further changes are needed. Thanks.
