### PR TITLE
Deprecating n_jobs in CBLOF

### DIFF
--- a/pyod/models/cblof.py
+++ b/pyod/models/cblof.py
@@ -92,9 +92,9 @@ class CBLOF(BaseDetector):
         number generator; If None, the random number generator is the
         RandomState instance used by `np.random`.
 
-    n_jobs : integer, optional (default=1)
-        The number of jobs to run in parallel for both `fit` and `predict`.
-        If -1, then the number of jobs is set to the number of cores.
+    n_jobs : integer, optional (default='deprecated')
+        DEPRECATED
+        No effect.
 
     Attributes
     ----------
@@ -139,7 +139,7 @@ class CBLOF(BaseDetector):
     def __init__(self, n_clusters=8, contamination=0.1,
                  clustering_estimator=None, alpha=0.9, beta=5,
                  use_weights=False, check_estimator=False, random_state=None,
-                 n_jobs=1):
+                 n_jobs='deprecated'):
         super(CBLOF, self).__init__(contamination=contamination)
         self.n_clusters = n_clusters
         self.clustering_estimator = clustering_estimator
@@ -148,7 +148,9 @@ class CBLOF(BaseDetector):
         self.use_weights = use_weights
         self.check_estimator = check_estimator
         self.random_state = random_state
-        self.n_jobs = n_jobs
+        if n_jobs != 'deprecated':
+            warnings.warn("'n_jobs' is deprecated and will be"
+                          " removed in a future version.", FutureWarning)
 
     # noinspection PyIncorrectDocstring
     def fit(self, X, y=None):
@@ -177,8 +179,7 @@ class CBLOF(BaseDetector):
         # number of clusters are default to 8
         self._validate_estimator(default=KMeans(
             n_clusters=self.n_clusters,
-            random_state=self.random_state,
-            n_jobs=self.n_jobs))
+            random_state=self.random_state))
 
         self.clustering_estimator_.fit(X=X, y=y)
         # Get the labels of the clustering results

--- a/pyod/test/test_cblof.py
+++ b/pyod/test/test_cblof.py
@@ -7,15 +7,9 @@ import sys
 
 import unittest
 # noinspection PyProtectedMember
-from sklearn.utils.testing import assert_allclose
-from sklearn.utils.testing import assert_array_less
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_greater_equal
-from sklearn.utils.testing import assert_less_equal
-from sklearn.utils.testing import assert_raises
+from numpy.testing import assert_allclose
+from numpy.testing import assert_array_less
 
-from sklearn.utils.estimator_checks import check_estimator
 from sklearn.metrics import roc_auc_score
 from scipy.stats import rankdata
 
@@ -33,9 +27,9 @@ class TestCBLOF(unittest.TestCase):
         self.n_test = 100
         self.contamination = 0.1
         self.roc_floor = 0.8
-        self.X_train, self.y_train, self.X_test, self.y_test = generate_data(
+        self.X_train, self.X_test, self.y_train, self.y_test = generate_data(
             n_train=self.n_train, n_test=self.n_test,
-            contamination=self.contamination, random_state=42)
+            contamination=self.contamination, behaviour='new', random_state=42)
 
         self.clf = CBLOF(contamination=self.contamination, random_state=42)
         self.clf.fit(self.X_train)
@@ -69,41 +63,42 @@ class TestCBLOF(unittest.TestCase):
                 self.clf._large_cluster_centers is not None)
 
     def test_train_scores(self):
-        assert_equal(len(self.clf.decision_scores_), self.X_train.shape[0])
+        assert (len(self.clf.decision_scores_) == self.X_train.shape[0])
 
     def test_prediction_scores(self):
         pred_scores = self.clf.decision_function(self.X_test)
         # check score shapes
-        assert_equal(pred_scores.shape[0], self.X_test.shape[0])
+        assert (pred_scores.shape[0] == self.X_test.shape[0])
         # check performance
-        assert_greater(roc_auc_score(self.y_test, pred_scores), self.roc_floor)
+        self.assertGreater(roc_auc_score(self.y_test, pred_scores),
+                           self.roc_floor)
 
     def test_prediction_labels(self):
         pred_labels = self.clf.predict(self.X_test)
-        assert_equal(pred_labels.shape, self.y_test.shape)
+        assert (pred_labels.shape == self.y_test.shape)
 
     def test_prediction_proba(self):
         pred_proba = self.clf.predict_proba(self.X_test)
-        assert_greater_equal(pred_proba.min(), 0)
-        assert_less_equal(pred_proba.max(), 1)
+        self.assertGreaterEqual(pred_proba.min(), 0)
+        self.assertLessEqual(pred_proba.max(), 1)
 
     def test_prediction_proba_linear(self):
         pred_proba = self.clf.predict_proba(self.X_test, method='linear')
-        assert_greater_equal(pred_proba.min(), 0)
-        assert_less_equal(pred_proba.max(), 1)
+        self.assertGreaterEqual(pred_proba.min(), 0)
+        self.assertLessEqual(pred_proba.max(), 1)
 
     def test_prediction_proba_unify(self):
         pred_proba = self.clf.predict_proba(self.X_test, method='unify')
-        assert_greater_equal(pred_proba.min(), 0)
-        assert_less_equal(pred_proba.max(), 1)
+        self.assertGreaterEqual(pred_proba.min(), 0)
+        self.assertLessEqual(pred_proba.max(), 1)
 
     def test_prediction_proba_parameter(self):
-        with assert_raises(ValueError):
+        with self.assertRaises(ValueError):
             self.clf.predict_proba(self.X_test, method='something')
 
     def test_fit_predict(self):
         pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
+        assert (pred_labels.shape == self.y_train.shape)
 
     def test_fit_predict_score(self):
         self.clf.fit_predict_score(self.X_test, self.y_test)
@@ -111,7 +106,7 @@ class TestCBLOF(unittest.TestCase):
                                    scoring='roc_auc_score')
         self.clf.fit_predict_score(self.X_test, self.y_test,
                                    scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
+        with self.assertRaises(NotImplementedError):
             self.clf.fit_predict_score(self.X_test, self.y_test,
                                        scoring='something')
 


### PR DESCRIPTION
### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

In this PR, I propose to deprecate n_jobs in CBLOF and to remove the corresponding parameter from the call to KMeans in order to avoid the deprecation warnings.