### PR TITLE
Added slight optimization to LMDD

### DIFF
--- a/pyod/models/lmdd.py
+++ b/pyod/models/lmdd.py
@@ -176,14 +176,11 @@ class LMDD(BaseDetector):
         if var_max > res_[j]:
             res_[j] = var_max
 
-        if var_max > 0:
             for k in range(j + 1, X.shape[0]):
-                dk_diff = (self.dis_measure_(
-                    np.vstack((X[:j], X[k]))) - self.dis_measure_(X[:j])) \
-                          - (self.dis_measure_(np.vstack((X[:j + 1], X[k])))
-                             - self.dis_measure_(X[:j + 1]))
-                if dk_diff >= var_max:
-                    res_[k] = dk_diff
+                dk_diff = self.dis_measure_(np.vstack((X[:j], X[k])))\
+                        - self.dis_measure_(np.vstack((X[:j + 1], X[k]))) 
+                if dk_diff >= 0:
+                    res_[k] = dk_diff + var_max
 
         return res_
 


### PR DESCRIPTION
The current LMDD model implements the original paper method naively. 
Some easy optimizations are possible:
- "if var_max > res_[j] and if var_max > 0" can be collapsed into a single if statement because res_ is initialized as zeroes.
- var_max = self.dis_measure_(X[:i + 1]) - self.dis_measure_(X[:i]), because j = i, var_max is also equal to self.dis_measure_(X[:j + 1]) - self.dis_measure_(X[:j]), meaning we can replace these terms by var_max in the calculation of dk_diff.
- dk_diff >= var_max can be replaced by dk_diff - var_max >= 0
- We only need to add var_max into dk_diff if we actually assign it to res_[k], so the if statement can be further simplified. 

This PR implements these changes in the most basic manner, leading to a small speed increase. 

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.


