### PR TITLE
Improve cof memory management

### DIFF
--- a/pyod/models/cof.py
+++ b/pyod/models/cof.py
@@ -136,24 +136,22 @@ class COF(BaseDetector):
                  The greater the COF, the greater the outlierness.
         """
         #dist_matrix = np.array(distance_matrix(X, X))
-        sbn_path_index, ac_dist, cof_ = [], [], []
+        sbn_path_index = np.zeros((X.shape[0],self.n_neighbors_), dtype=np.int64)
+        ac_dist, cof_ = np.zeros((X.shape[0])), np.zeros((X.shape[0]))
         for i in range(X.shape[0]):
             #sbn_path = np.argsort(dist_matrix[i])
             sbn_path = np.argsort(minkowski_distance(X[i,:],X,p=2))
-            sbn_path_index.append(sbn_path[1: self.n_neighbors_ + 1])
-            cost_desc = []
+            sbn_path_index[i,:] = sbn_path[1: self.n_neighbors_ + 1]
+            cost_desc = np.zeros((self.n_neighbors_))
             for j in range(self.n_neighbors_):
                 #cost_desc.append(
                 #    np.min(dist_matrix[sbn_path[j + 1]][sbn_path][:j + 1]))
-                cost_desc.append(
-                    np.min(minkowski_distance(X[sbn_path[j + 1]],X,p=2)[sbn_path][:j + 1]))
-            acd = []
+                cost_desc[j] = np.min(minkowski_distance(X[sbn_path[j + 1]],X,p=2)[sbn_path][:j + 1])
+            acd = np.zeros((self.n_neighbors_))
             for _h, cost_ in enumerate(cost_desc):
                 neighbor_add1 = self.n_neighbors_ + 1
-                acd.append(((2. * (neighbor_add1 - (_h + 1))) / (
-                        neighbor_add1 * self.n_neighbors_)) * cost_)
-            ac_dist.append(np.sum(acd))
+                acd[_h] = ((2. * (neighbor_add1 - (_h + 1))) / (neighbor_add1 * self.n_neighbors_)) * cost_
+            ac_dist[i] = np.sum(acd)
         for _g in range(X.shape[0]):
-            cof_.append((ac_dist[_g] * self.n_neighbors_) /
-                        np.sum(itemgetter(*sbn_path_index[_g])(ac_dist)))
+            cof_[_g] = (ac_dist[_g] * self.n_neighbors_) / np.sum(ac_dist[sbn_path_index[_g]])
         return np.nan_to_num(cof_)

--- a/pyod/models/cof.py
+++ b/pyod/models/cof.py
@@ -11,7 +11,8 @@ import warnings
 from operator import itemgetter
 
 import numpy as np
-from scipy.spatial import distance_matrix
+#from scipy.spatial import distance_matrix
+from scipy.spatial import minkowski_distance
 from sklearn.utils import check_array
 
 from .base import BaseDetector
@@ -134,15 +135,18 @@ class COF(BaseDetector):
         :return: numpy array containing COF scores for observations.
                  The greater the COF, the greater the outlierness.
         """
-        dist_matrix = np.array(distance_matrix(X, X))
+        #dist_matrix = np.array(distance_matrix(X, X))
         sbn_path_index, ac_dist, cof_ = [], [], []
         for i in range(X.shape[0]):
-            sbn_path = np.argsort(dist_matrix[i])
+            #sbn_path = np.argsort(dist_matrix[i])
+            sbn_path = np.argsort(minkowski_distance(X[i,:],X,p=2))
             sbn_path_index.append(sbn_path[1: self.n_neighbors_ + 1])
             cost_desc = []
             for j in range(self.n_neighbors_):
+                #cost_desc.append(
+                #    np.min(dist_matrix[sbn_path[j + 1]][sbn_path][:j + 1]))
                 cost_desc.append(
-                    np.min(dist_matrix[sbn_path[j + 1]][sbn_path][:j + 1]))
+                    np.min(minkowski_distance(X[sbn_path[j + 1]],X,p=2)[sbn_path][:j + 1]))
             acd = []
             for _h, cost_ in enumerate(cost_desc):
                 neighbor_add1 = self.n_neighbors_ + 1

--- a/pyod/test/test_cof.py
+++ b/pyod/test/test_cof.py
@@ -23,7 +23,7 @@ from pyod.models.cof import COF
 from pyod.utils.data import generate_data
 
 
-class TestCOF(unittest.TestCase):
+class TestFastCOF(unittest.TestCase):
     def setUp(self):
         self.n_train = 100
         self.n_test = 50
@@ -130,6 +130,113 @@ class TestCOF(unittest.TestCase):
     def tearDown(self):
         pass
 
+
+class TestMemoryCOF(unittest.TestCase):
+    def setUp(self):
+        self.n_train = 100
+        self.n_test = 50
+        self.contamination = 0.1
+        self.roc_floor = 0.8
+        self.X_train, self.y_train, self.X_test, self.y_test = generate_data(
+            n_train=self.n_train, n_test=self.n_test,
+            contamination=self.contamination, random_state=42)
+
+        self.clf = COF(contamination=self.contamination, method="memory")
+        self.clf.fit(self.X_train)
+
+    def test_parameters(self):
+        assert (hasattr(self.clf, 'decision_scores_') and
+                self.clf.decision_scores_ is not None)
+        assert (hasattr(self.clf, 'labels_') and
+                self.clf.labels_ is not None)
+        assert (hasattr(self.clf, 'threshold_') and
+                self.clf.threshold_ is not None)
+        assert (hasattr(self.clf, 'n_neighbors_') and
+                self.clf.n_neighbors_ is not None)
+
+    def test_train_scores(self):
+        assert_equal(len(self.clf.decision_scores_), self.X_train.shape[0])
+
+    def test_prediction_scores(self):
+        pred_scores = self.clf.decision_function(self.X_test)
+
+        # check score shapes
+        assert_equal(pred_scores.shape[0], self.X_test.shape[0])
+
+        # check performance
+        assert (roc_auc_score(self.y_test, pred_scores) >= self.roc_floor)
+
+    def test_prediction_labels(self):
+        pred_labels = self.clf.predict(self.X_test)
+        assert_equal(pred_labels.shape, self.y_test.shape)
+
+    def test_prediction_proba(self):
+        pred_proba = self.clf.predict_proba(self.X_test)
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_linear(self):
+        pred_proba = self.clf.predict_proba(self.X_test, method='linear')
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_unify(self):
+        pred_proba = self.clf.predict_proba(self.X_test, method='unify')
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_parameter(self):
+        with assert_raises(ValueError):
+            self.clf.predict_proba(self.X_test, method='something')
+
+    def test_fit_predict(self):
+        pred_labels = self.clf.fit_predict(self.X_train)
+        assert_equal(pred_labels.shape, self.y_train.shape)
+
+    def test_fit_predict_score(self):
+        self.clf.fit_predict_score(self.X_test, self.y_test)
+        self.clf.fit_predict_score(self.X_test, self.y_test,
+                                   scoring='roc_auc_score')
+        self.clf.fit_predict_score(self.X_test, self.y_test,
+                                   scoring='prc_n_score')
+        with assert_raises(NotImplementedError):
+            self.clf.fit_predict_score(self.X_test, self.y_test,
+                                       scoring='something')
+
+    def test_predict_rank(self):
+        pred_scores = self.clf.decision_function(self.X_test)
+        pred_ranks = self.clf._predict_rank(self.X_test)
+        print(pred_ranks)
+
+        # assert the order is reserved
+        assert_allclose(rankdata(pred_ranks), rankdata(pred_scores), atol=2)
+        assert_array_less(pred_ranks, self.X_train.shape[0] + 1)
+        assert_array_less(-0.1, pred_ranks)
+
+    def test_predict_rank_normalized(self):
+        pred_socres = self.clf.decision_function(self.X_test)
+        pred_ranks = self.clf._predict_rank(self.X_test, normalized=True)
+
+        # assert the order is reserved
+        assert_allclose(rankdata(pred_ranks), rankdata(pred_socres), atol=2)
+        assert_array_less(pred_ranks, 1.01)
+        assert_array_less(-0.1, pred_ranks)
+
+    def test_check_parameters(self):
+        with assert_raises(ValueError):
+            COF(contamination=0.1, n_neighbors=-1)
+        with assert_raises(ValueError):
+            COF(contamination=10., n_neighbors=5)
+        with assert_raises(TypeError):
+            COF(contamination=0.1, n_neighbors='not int')
+        with assert_raises(TypeError):
+            COF(contamination='not float', n_neighbors=5)
+        cof_ = COF(contamination=0.1, n_neighbors=10000)
+        cof_.fit(self.X_train)
+        assert self.X_train.shape[0] > cof_.n_neighbors_
+
+    def tearDown(self):
+        pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds functionality to COF to allow for the selection of one of two methods:
"fast" which will use the old calculation using the full pairwise distance matrix.
"memory" which will use a new method, which only calculates distances when needed, thus saving on memory at the price of speed.

This PR follows up on issue #315


### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.
