### PR TITLE
Automatic histogram size selection

### DIFF
--- a/pyod/models/hbos.py
+++ b/pyod/models/hbos.py
@@ -14,6 +14,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from ..utils.utility import check_parameter
 from ..utils.utility import invert_order
+from ..utils.utility import get_optimal_n_bins
 
 from .base import BaseDetector
 
@@ -26,8 +27,9 @@ class HBOS(BaseDetector):
 
     Parameters
     ----------
-    n_bins : int, optional (default=10)
-        The number of bins.
+    n_bins : int or string, optional (default=10)
+        The number of bins. "auto" uses the birge-rozenblac method for
+        automatic selection of the optimal number of bins for each feature.
 
     alpha : float in (0, 1), optional (default=0.1)
         The regularizer for preventing overflow.
@@ -95,23 +97,45 @@ class HBOS(BaseDetector):
         X = check_array(X)
         self._set_n_classes(y)
 
-        n_samples, n_features = X.shape[0], X.shape[1]
-        self.hist_ = np.zeros([self.n_bins, n_features])
-        self.bin_edges_ = np.zeros([self.n_bins + 1, n_features])
+        _, n_features = X.shape[0], X.shape[1]
+        
+        if isinstance(self.n_bins, str) and self.n_bins.lower() == "auto":
+            #Uses the birge rozenblac method for automatic histogram size per feature
+            self.hist_ = []
+            self.bin_edges_ = []
+            
+            # build the histograms for all dimensions
+            for i in range(n_features):
+                n_bins = get_optimal_n_bins(X[:,i])
+                hist, bin_edges = np.histogram(X[:, i], bins=n_bins, density=True)
+                self.hist_.append(hist)
+                self.bin_edges_.append(bin_edges)
+                # the sum of (width * height) should equal to 1
+                assert (np.isclose(1, np.sum(
+                    hist * np.diff(bin_edges)), atol=0.1))
+                
+            outlier_scores = _calculate_outlier_scores_auto(X, self.bin_edges_,
+                                                            self.hist_,
+                                                            self.alpha, self.tol)
+                
+        elif check_parameter(self.n_bins, low=2, high=np.inf):            
+            self.hist_ = np.zeros([self.n_bins, n_features])
+            self.bin_edges_ = np.zeros([self.n_bins + 1, n_features])
+    
+            # build the histograms for all dimensions
+            for i in range(n_features):
+                self.hist_[:, i], self.bin_edges_[:, i] = \
+                    np.histogram(X[:, i], bins=self.n_bins, density=True)
+                # the sum of (width * height) should equal to 1
+                assert (np.isclose(1, np.sum(
+                    self.hist_[:, i] * np.diff(self.bin_edges_[:, i])), atol=0.1))
+                
+            outlier_scores = _calculate_outlier_scores(X, self.bin_edges_,
+                                                       self.hist_,
+                                                       self.n_bins,
+                                                       self.alpha, self.tol)
 
-        # build the histograms for all dimensions
-        for i in range(n_features):
-            self.hist_[:, i], self.bin_edges_[:, i] = \
-                np.histogram(X[:, i], bins=self.n_bins, density=True)
-            # the sum of (width * height) should equal to 1
-            assert (np.isclose(1, np.sum(
-                self.hist_[:, i] * np.diff(self.bin_edges_[:, i])), atol=0.1))
 
-        # outlier_scores = self._calculate_outlier_scores(X)
-        outlier_scores = _calculate_outlier_scores(X, self.bin_edges_,
-                                                   self.hist_,
-                                                   self.n_bins,
-                                                   self.alpha, self.tol)
 
         # invert decision_scores_. Outliers comes with higher outlier scores
         self.decision_scores_ = invert_order(np.sum(outlier_scores, axis=1))
@@ -139,13 +163,101 @@ class HBOS(BaseDetector):
         check_is_fitted(self, ['hist_', 'bin_edges_'])
         X = check_array(X)
 
-        # outlier_scores = self._calculate_outlier_scores(X)
-        outlier_scores = _calculate_outlier_scores(X, self.bin_edges_,
-                                                   self.hist_,
-                                                   self.n_bins,
-                                                   self.alpha, self.tol)
+        if isinstance(self.n_bins, str) and self.n_bins.lower() == "auto":
+            outlier_scores = _calculate_outlier_scores_auto(X, self.bin_edges_,
+                                                            self.hist_,
+                                                            self.alpha, self.tol)
+        elif check_parameter(self.n_bins, low=2, high=np.inf): 
+            outlier_scores = _calculate_outlier_scores(X, self.bin_edges_,
+                                                       self.hist_,
+                                                       self.n_bins,
+                                                       self.alpha, self.tol)
         return invert_order(np.sum(outlier_scores, axis=1))
 
+#@njit #due to variable size of histograms, can no longer naively use numba for jit
+def _calculate_outlier_scores_auto(X, bin_edges, hist, alpha,
+                              tol):  # pragma: no cover
+    """The internal function to calculate the outlier scores based on
+    the bins and histograms constructed with the training data. The program
+    is optimized through numba. It is excluded from coverage test for
+    eliminating the redundancy.
+
+    Parameters
+    ----------
+    X : numpy array of shape (n_samples, n_features
+        The input samples.
+
+    bin_edges : list of length n_features containing numpy arrays
+        The edges of the bins.
+
+    hist : =list of length n_features containing numpy arrays
+        The density of each histogram.
+
+    alpha : float in (0, 1)
+        The regularizer for preventing overflow.
+
+    tol : float in (0, 1)
+        The parameter to decide the flexibility while dealing
+        the samples falling outside the bins.
+
+    Returns
+    -------
+    outlier_scores : numpy array of shape (n_samples, n_features)
+        Outlier scores on all features (dimensions).
+    """
+
+    n_samples, n_features = X.shape[0], X.shape[1]
+    outlier_scores = np.zeros(shape=(n_samples, n_features))
+
+    for i in range(n_features):
+
+        # Find the indices of the bins to which each value belongs.
+        # See documentation for np.digitize since it is tricky
+        # >>> x = np.array([0.2, 6.4, 3.0, 1.6, -1, 100, 10])
+        # >>> bins = np.array([0.0, 1.0, 2.5, 4.0, 10.0])
+        # >>> np.digitize(x, bins, right=True)
+        # array([1, 4, 3, 2, 0, 5, 4], dtype=int64)
+
+        bin_inds = np.digitize(X[:, i], bin_edges[i], right=True)
+
+        # Calculate the outlying scores on dimension i
+        # Add a regularizer for preventing overflow
+        out_score_i = np.log2(hist[i] + alpha)
+        
+        
+        optimal_n_bins = get_optimal_n_bins(X[:,i])
+
+        for j in range(n_samples):
+
+            # If the sample does not belong to any bins
+            # bin_ind == 0 (fall outside since it is too small)
+            if bin_inds[j] == 0:
+                dist = bin_edges[i][0] - X[j, i]
+                bin_width = bin_edges[i][1] - bin_edges[i][0]
+
+                # If it is only slightly lower than the smallest bin edge
+                # assign it to bin 1
+                if dist <= bin_width * tol:
+                    outlier_scores[j, i] = out_score_i[0]
+                else:
+                    outlier_scores[j, i] = np.min(out_score_i)
+
+            # If the sample does not belong to any bins
+            # bin_ind == optimal_n_bins+1 (fall outside since it is too large)
+            elif bin_inds[j] == optimal_n_bins + 1:
+                dist = X[j, i] - bin_edges[i][-1]
+                bin_width = bin_edges[i][-1] - bin_edges[i][-2]
+
+                # If it is only slightly larger than the largest bin edge
+                # assign it to the last bin
+                if dist <= bin_width * tol:
+                    outlier_scores[j, i] = out_score_i[optimal_n_bins - 1]
+                else:
+                    outlier_scores[j, i] = np.min(out_score_i)
+            else:
+                outlier_scores[j, i] = out_score_i[bin_inds[j] - 1]
+                
+    return outlier_scores
 
 @njit
 def _calculate_outlier_scores(X, bin_edges, hist, n_bins, alpha,
@@ -166,13 +278,13 @@ def _calculate_outlier_scores(X, bin_edges, hist, n_bins, alpha,
     hist : numpy array of shape (n_bins, n_features)
         The density of each histogram.
 
-    n_bins : int, optional (default=10)
-        The number of bins.
+    n_bins : int
+        The number of bins. 
 
-    alpha : float in (0, 1), optional (default=0.1)
+    alpha : float in (0, 1)
         The regularizer for preventing overflow.
 
-    tol : float in (0, 1), optional (default=0.1)
+    tol : float in (0, 1)
         The parameter to decide the flexibility while dealing
         the samples falling outside the bins.
 

--- a/pyod/models/loda.py
+++ b/pyod/models/loda.py
@@ -8,6 +8,7 @@ Adapted from tilitools (https://github.com/nicococo/tilitools) by
 from __future__ import division
 from __future__ import print_function
 
+import numbers
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils import check_array
@@ -26,8 +27,10 @@ class LODA(BaseDetector):
         i.e. the proportion of outliers in the data set. Used when fitting to
         define the threshold on the decision function.
 
-    n_bins : int, optional (default = 10)
-        The number of bins for the histogram.
+    n_bins : int or string, optional (default = 10)
+        The number of bins for the histogram. If set to "auto", the 
+        Birge-Rozenblac method will be used to automatically determine the 
+        optimal number of bins.
 
     n_random_cuts : int, optional (default = 100)
         The number of random cuts.
@@ -84,6 +87,17 @@ class LODA(BaseDetector):
         n_zero_components = n_components - np.int(n_nonzero_components)
 
         self.projections_ = np.random.randn(self.n_random_cuts, n_components)
+        
+        # If set to auto: determine optimal n_bins using Birge Rozenblac method
+        if isinstance(self.n_bins, str) and self.n_bins.to_lower() == "auto":
+            optimal_n_bins = get_optimal_n_bins(X)
+            self.n_bins_ = optimal_n_bins
+        if isinstance(self.n_bins, numbers.Integral):
+            self.n_bins_ = self.n_bins
+        else:
+            raise ValueError("n_bins must be an int or \'auto\', "
+                             "got: %f" % self.n_bins)
+            
         self.histograms_ = np.zeros((self.n_random_cuts, self.n_bins))
         self.limits_ = np.zeros((self.n_random_cuts, self.n_bins + 1))
         for i in range(self.n_random_cuts):

--- a/pyod/test/test_hbos.py
+++ b/pyod/test/test_hbos.py
@@ -135,6 +135,114 @@ class TestHBOS(unittest.TestCase):
     def tearDown(self):
         pass
 
+class TestAutoHBOS(unittest.TestCase):
+    def setUp(self):
+        self.n_train = 200
+        self.n_test = 100
+        self.contamination = 0.1
+        self.roc_floor = 0.8
+        self.X_train, self.y_train, self.X_test, self.y_test = generate_data(
+            n_train=self.n_train, n_test=self.n_test,
+            contamination=self.contamination, random_state=42)
+
+        self.clf = HBOS(contamination=self.contamination, n_bins="auto")
+        self.clf.fit(self.X_train)
+
+    def test_parameters(self):
+        assert (hasattr(self.clf, 'decision_scores_') and
+                self.clf.decision_scores_ is not None)
+        assert (hasattr(self.clf, 'labels_') and
+                self.clf.labels_ is not None)
+        assert (hasattr(self.clf, 'threshold_') and
+                self.clf.threshold_ is not None)
+        assert (hasattr(self.clf, '_mu') and
+                self.clf._mu is not None)
+        assert (hasattr(self.clf, '_sigma') and
+                self.clf._sigma is not None)
+        assert (hasattr(self.clf, 'hist_') and
+                self.clf.hist_ is not None)
+        assert (hasattr(self.clf, 'bin_edges_') and
+                self.clf.bin_edges_ is not None)
+
+    def test_train_scores(self):
+        assert_equal(len(self.clf.decision_scores_), self.X_train.shape[0])
+
+    def test_prediction_scores(self):
+        pred_scores = self.clf.decision_function(self.X_test)
+
+        # check score shapes
+        assert_equal(pred_scores.shape[0], self.X_test.shape[0])
+
+        # check performance
+        assert (roc_auc_score(self.y_test, pred_scores) >= self.roc_floor)
+
+    def test_prediction_labels(self):
+        pred_labels = self.clf.predict(self.X_test)
+        assert_equal(pred_labels.shape, self.y_test.shape)
+
+    def test_prediction_proba(self):
+        pred_proba = self.clf.predict_proba(self.X_test)
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_linear(self):
+        pred_proba = self.clf.predict_proba(self.X_test, method='linear')
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_unify(self):
+        pred_proba = self.clf.predict_proba(self.X_test, method='unify')
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_parameter(self):
+        with assert_raises(ValueError):
+            self.clf.predict_proba(self.X_test, method='something')
+
+    def test_fit_predict(self):
+        pred_labels = self.clf.fit_predict(self.X_train)
+        assert_equal(pred_labels.shape, self.y_train.shape)
+
+    def test_fit_predict_score(self):
+        self.clf.fit_predict_score(self.X_test, self.y_test)
+        self.clf.fit_predict_score(self.X_test, self.y_test,
+                                   scoring='roc_auc_score')
+        self.clf.fit_predict_score(self.X_test, self.y_test,
+                                   scoring='prc_n_score')
+        with assert_raises(NotImplementedError):
+            self.clf.fit_predict_score(self.X_test, self.y_test,
+                                       scoring='something')
+
+    # def test_score(self):
+    #     self.clf.score(self.X_test, self.y_test)
+    #     self.clf.score(self.X_test, self.y_test, scoring='roc_auc_score')
+    #     self.clf.score(self.X_test, self.y_test, scoring='prc_n_score')
+    #     with assert_raises(NotImplementedError):
+    #         self.clf.score(self.X_test, self.y_test, scoring='something')
+
+    def test_predict_rank(self):
+        pred_socres = self.clf.decision_function(self.X_test)
+        pred_ranks = self.clf._predict_rank(self.X_test)
+
+        # assert the order is reserved
+        assert_allclose(rankdata(pred_ranks), rankdata(pred_socres), atol=2)
+        assert_array_less(pred_ranks, self.X_train.shape[0] + 1)
+        assert_array_less(-0.1, pred_ranks)
+
+    def test_predict_rank_normalized(self):
+        pred_socres = self.clf.decision_function(self.X_test)
+        pred_ranks = self.clf._predict_rank(self.X_test, normalized=True)
+
+        # assert the order is reserved
+        assert_allclose(rankdata(pred_ranks), rankdata(pred_socres), atol=2)
+        assert_array_less(pred_ranks, 1.01)
+        assert_array_less(-0.1, pred_ranks)
+
+    def test_model_clone(self):
+        clone_clf = clone(self.clf)
+
+    def tearDown(self):
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyod/test/test_loda.py
+++ b/pyod/test/test_loda.py
@@ -106,6 +106,87 @@ class TestLODA(unittest.TestCase):
     def tearDown(self):
         pass
 
+class TestAutoLODA(unittest.TestCase):
+    def setUp(self):
+        self.n_train = 200
+        self.n_test = 100
+        self.contamination = 0.1
+        self.roc_floor = 0.8
+        self.X_train, self.y_train, self.X_test, self.y_test = generate_data(
+            n_train=self.n_train, n_test=self.n_test,
+            contamination=self.contamination, random_state=42)
+
+        self.clf = LODA(contamination=self.contamination)
+        self.clf.fit(self.X_train)
+
+    def test_parameters(self):
+        assert (hasattr(self.clf, 'decision_scores_') and
+                self.clf.decision_scores_ is not None)
+        assert (hasattr(self.clf, 'labels_') and
+                self.clf.labels_ is not None)
+        assert (hasattr(self.clf, 'threshold_') and
+                self.clf.threshold_ is not None)
+        assert (hasattr(self.clf, '_mu') and
+                self.clf._mu is not None)
+        assert (hasattr(self.clf, '_sigma') and
+                self.clf._sigma is not None)
+        assert (hasattr(self.clf, 'projections_') and
+                self.clf.projections_ is not None)
+
+    def test_train_scores(self):
+        assert_equal(len(self.clf.decision_scores_), self.X_train.shape[0])
+
+    def test_prediction_scores(self):
+        pred_scores = self.clf.decision_function(self.X_test)
+
+        # check score shapes
+        assert_equal(pred_scores.shape[0], self.X_test.shape[0])
+
+        # check performance
+        assert (roc_auc_score(self.y_test, pred_scores) >= self.roc_floor)
+
+    def test_prediction_labels(self):
+        pred_labels = self.clf.predict(self.X_test)
+        assert_equal(pred_labels.shape, self.y_test.shape)
+
+    def test_prediction_proba(self):
+        pred_proba = self.clf.predict_proba(self.X_test)
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_linear(self):
+        pred_proba = self.clf.predict_proba(self.X_test, method='linear')
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_unify(self):
+        pred_proba = self.clf.predict_proba(self.X_test, method='unify')
+        assert (pred_proba.min() >= 0)
+        assert (pred_proba.max() <= 1)
+
+    def test_prediction_proba_parameter(self):
+        with assert_raises(ValueError):
+            self.clf.predict_proba(self.X_test, method='something')
+
+    def test_fit_predict(self):
+        pred_labels = self.clf.fit_predict(self.X_train)
+        assert_equal(pred_labels.shape, self.y_train.shape)
+
+    def test_fit_predict_score(self):
+        self.clf.fit_predict_score(self.X_test, self.y_test)
+        self.clf.fit_predict_score(self.X_test, self.y_test,
+                                   scoring='roc_auc_score')
+        self.clf.fit_predict_score(self.X_test, self.y_test,
+                                   scoring='prc_n_score')
+        with assert_raises(NotImplementedError):
+            self.clf.fit_predict_score(self.X_test, self.y_test,
+                                       scoring='something')
+
+    def test_model_clone(self):
+        clone_clf = clone(self.clf)
+
+    def tearDown(self):
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyod/utils/__init__.py
+++ b/pyod/utils/__init__.py
@@ -6,6 +6,7 @@ from .utility import precision_n_scores
 from .utility import get_label_n
 from .utility import argmaxn
 from .utility import invert_order
+from .utility import get_optimal_n_bins
 from .data import generate_data
 from .data import evaluate_print
 from .stat_models import pairwise_distances_no_broadcast
@@ -23,4 +24,5 @@ __all__ = ['check_parameter',
            'evaluate_print',
            'pairwise_distances_no_broadcast',
            'wpearsonr',
-           'pearsonr_mat']
+           'pearsonr_mat',
+           'get_optimal_n_bins']

--- a/pyod/utils/__init__.py
+++ b/pyod/utils/__init__.py
@@ -6,7 +6,6 @@ from .utility import precision_n_scores
 from .utility import get_label_n
 from .utility import argmaxn
 from .utility import invert_order
-from .utility import get_optimal_n_bins
 from .data import generate_data
 from .data import evaluate_print
 from .stat_models import pairwise_distances_no_broadcast
@@ -24,5 +23,4 @@ __all__ = ['check_parameter',
            'evaluate_print',
            'pairwise_distances_no_broadcast',
            'wpearsonr',
-           'pearsonr_mat',
-           'get_optimal_n_bins']
+           'pearsonr_mat']

--- a/pyod/utils/__init__.py
+++ b/pyod/utils/__init__.py
@@ -6,6 +6,7 @@ from .utility import precision_n_scores
 from .utility import get_label_n
 from .utility import argmaxn
 from .utility import invert_order
+from .utility import get_optimal_n_bins
 from .data import generate_data
 from .data import evaluate_print
 from .stat_models import pairwise_distances_no_broadcast
@@ -19,6 +20,7 @@ __all__ = ['check_parameter',
            'get_label_n',
            'argmaxn',
            'invert_order',
+           'get_optimal_n_bins',
            'generate_data',
            'evaluate_print',
            'pairwise_distances_no_broadcast',

--- a/pyod/utils/utility.py
+++ b/pyod/utils/utility.py
@@ -544,3 +544,39 @@ def generate_indices(random_state, bootstrap, n_population, n_samples):
                                              random_state=random_state)
 
     return indices
+
+def get_optimal_n_bins(X, upper_bound = None, epsilon = 1): 
+    """ Determine optimal number of bins for a histogram using the Birge 
+    Rozenblac method. 
+     
+    See  https://doi.org/10.1051/ps:2006001 
+     
+    Parameters 
+    ---------- 
+    X : array-like of shape (n_samples, n_features) 
+        The samples to determine the optimal number of bins for. 
+         
+    upper_bound :  int, default=None 
+        The maximum value of n_bins to be considered. 
+        If set to None, np.sqrt(X.shape[0]) will be used as upper bound. 
+         
+    epsilon : float, default = 1 
+        A stabilizing term added to the logarithm to prevent division by zero. 
+         
+    Returns 
+    ------- 
+    optimal_n_bins : int 
+        The optimal value of n_bins according to the Birge Rozenblac method 
+    """ 
+    if upper_bound is None: 
+        upper_bound = np.sqrt(X.shape[0]) 
+     
+    n = X.shape[0] 
+    maximum_likelihood = np.zeros((upper_bound-1,1)) 
+     
+    for i, b in enumerate(range(1,upper_bound)): 
+        histogram, _ = np.histogram(X, bins=b) 
+         
+        maximum_likelihood[i] = np.sum(histogram * np.log(b*histogram/n + epsilon) - (b - 1 + np.power(np.log(b),2.5))) 
+                                       
+    return np.argmax(maximum_likelihood) + 1                                   

--- a/pyod/utils/utility.py
+++ b/pyod/utils/utility.py
@@ -569,7 +569,7 @@ def get_optimal_n_bins(X, upper_bound = None, epsilon = 1):
         The optimal value of n_bins according to the Birge Rozenblac method 
     """ 
     if upper_bound is None: 
-        upper_bound = np.sqrt(X.shape[0]) 
+        upper_bound = int(np.sqrt(X.shape[0])) 
      
     n = X.shape[0] 
     maximum_likelihood = np.zeros((upper_bound-1,1)) 

--- a/pyod/utils/utility.py
+++ b/pyod/utils/utility.py
@@ -280,6 +280,73 @@ def get_label_n(y, y_pred, n=None):
     return y_pred
 
 
+def get_intersection(lst1, lst2):
+    """get the overlapping between two lists
+
+    Parameters
+    ----------
+    li1 : list or numpy array
+        Input list 1.
+
+    li2 : list or numpy array
+        Input list 2.
+
+    Returns
+    -------
+    difference : list
+        The overlapping between li1 and li2.
+    """
+    return list(set(lst1) & set(lst2))
+
+
+def get_list_diff(li1, li2):
+    """get the elements in li1 but not li2. li1-li2
+
+    Parameters
+    ----------
+    li1 : list or numpy array
+        Input list 1.
+
+    li2 : list or numpy array
+        Input list 2.
+
+    Returns
+    -------
+    difference : list
+        The difference between li1 and li2.
+    """
+    # if isinstance(li1, (np.ndarray, np.generic)):
+    #     li1 = li1.tolist()
+    # if isinstance(li2, (np.ndarray, np.generic)):
+    #     li1 = li1.tolist()
+
+    return (list(set(li1) - set(li2)))
+
+
+def get_diff_elements(li1, li2):
+    """get the elements in li1 but not li2, and vice versa
+
+    Parameters
+    ----------
+    li1 : list or numpy array
+        Input list 1.
+
+    li2 : list or numpy array
+        Input list 2.
+
+    Returns
+    -------
+    difference : list
+        The difference between li1 and li2.
+    """
+    # if isinstance(li1, (np.ndarray, np.generic)):
+    #     li1 = li1.tolist()
+    # if isinstance(li2, (np.ndarray, np.generic)):
+    #     li1 = li1.tolist()
+
+    return (list(set(li1) - set(li2)) + list(set(li2) - set(li1)))
+
+
 def argmaxn(value_list, n, order='desc'):
     """Return the index of top n elements in the list
     if order is set to 'desc', otherwise return the index of n smallest ones.
@@ -375,28 +442,28 @@ def _get_sklearn_version():  # pragma: no cover
 
     sklearn_version = str(sklearn.__version__)
     if int(sklearn_version.split(".")[1]) < 19 or int(
-            sklearn_version.split(".")[1]) > 23:
+            sklearn_version.split(".")[1]) > 24:
         raise ValueError("Sklearn version error")
 
     return int(sklearn_version.split(".")[1])
 
 
-def _sklearn_version_21():  # pragma: no cover
-    """ Utility function to decide the version of sklearn
-    In sklearn 21.0, LOF is changed. Specifically, _decision_function
-    is replaced by _score_samples
-
-    Returns
-    -------
-    sklearn_21_flag : bool
-        True if sklearn.__version__ is newer than 0.21.0
-
-    """
-    sklearn_version = str(sklearn.__version__)
-    if int(sklearn_version.split(".")[1]) > 20:
-        return True
-    else:
-        return False
+# def _sklearn_version_21():  # pragma: no cover
+#     """ Utility function to decide the version of sklearn
+#     In sklearn 21.0, LOF is changed. Specifically, _decision_function
+#     is replaced by _score_samples
+#
+#     Returns
+#     -------
+#     sklearn_21_flag : bool
+#         True if sklearn.__version__ is newer than 0.21.0
+#
+#     """
+#     sklearn_version = str(sklearn.__version__)
+#     if int(sklearn_version.split(".")[1]) > 20:
+#         return True
+#     else:
+#         return False
 
 
 def generate_bagging_indices(random_state, bootstrap_features, n_features,
@@ -477,40 +544,3 @@ def generate_indices(random_state, bootstrap, n_population, n_samples):
                                              random_state=random_state)
 
     return indices
-
-def get_optimal_n_bins(X, upper_bound = None, epsilon = 1):
-    """ Determine optimal number of bins for a histogram using the Birge
-    Rozenblac method.
-    
-    See  https://doi.org/10.1051/ps:2006001
-    
-    Parameters
-    ----------
-    X : array-like of shape (n_samples, n_features)
-        The samples to determine the optimal number of bins for.
-        
-    upper_bound :  int, default=None
-        The maximum value of n_bins to be considered.
-        If set to None, np.sqrt(X.shape[0]) will be used as upper bound.
-        
-    epsilon : float, default = 1
-        A stabilizing term added to the logarithm to prevent division by zero.
-        
-    Returns
-    -------
-    optimal_n_bins : int
-        The optimal value of n_bins according to the Birge Rozenblac method
-    """
-    if upper_bound is None:
-        upper_bound = np.sqrt(X.shape[0])
-    
-    n = X.shape[0]
-    maximum_likelihood = np.zeros((upper_bound-1,1))
-    
-    for i, b in enumerate(range(1,upper_bound)):
-        histogram, _ = np.histogram(X, bins=b)
-        
-        maximum_likelihood[i] = np.sum(histogram * np.log(b*histogram/n + epsilon) - (b - 1 + np.power(np.log(b),2.5)))
-                                      
-    return np.argmax(maximum_likelihood) + 1                                  
-        


### PR DESCRIPTION
This PR adds new functionality to PyOD by allowing for automatic determination of the optimal number of bins for histograms. This can therefore improve the results from HBOS and LODA.

The PR solves #189 

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.