### PR TITLE
Refactored PyTorch Autonencoder built up (Proposal to solve #434)

### DIFF
--- a/pyod/models/auto_encoder_torch.py
+++ b/pyod/models/auto_encoder_torch.py
@@ -44,50 +44,67 @@ class PyODDataset(torch.utils.data.Dataset):
         return torch.from_numpy(sample), idx
 
 
-class inner_autoencoder(nn.Module):
+class InnerAutoencoder(nn.Module):
     def __init__(self,
                  n_features,
-                 hidden_neurons=[128, 64],
+                 hidden_neurons=(128, 64),
                  dropout_rate=0.2,
                  batch_norm=True,
                  hidden_activation='relu'):
-        super(inner_autoencoder, self).__init__()
+
+        # initialize the super class
+        super(InnerAutoencoder, self).__init__()
+
+        # save the default values
         self.n_features = n_features
         self.dropout_rate = dropout_rate
         self.batch_norm = batch_norm
         self.hidden_activation = hidden_activation
 
+        # create the dimensions for the input and hidden layers
+        self.layers_neurons_encoder_ = [self.n_features, *hidden_neurons]
+        self.layers_neurons_decoder_ = self.layers_neurons_encoder_[::-1]
+
+        # get the object for the activations functions
         self.activation = get_activation_by_name(hidden_activation)
 
-        self.layers_neurons_ = [self.n_features, *hidden_neurons]
-        self.layers_neurons_decoder_ = self.layers_neurons_[::-1]
+        # initialize encoder and decoder as a sequential
         self.encoder = nn.Sequential()
         self.decoder = nn.Sequential()
 
-        for idx, layer in enumerate(self.layers_neurons_[:-1]):
-            if batch_norm:
+        # fill the encoder sequential with hidden layers
+        for idx, layer in enumerate(self.layers_neurons_encoder_[:-1]):
+
+            # add a batch norm per layer if wanted (leave out first layer)
+            if batch_norm and idx > 0:
                 self.encoder.add_module("batch_norm" + str(idx),
-                                        nn.BatchNorm1d(
-                                            self.layers_neurons_[idx]))
+                                        nn.BatchNorm1d(layer))
+
+            # create a linear layer of neurons
             self.encoder.add_module("linear" + str(idx),
-                                    torch.nn.Linear(self.layers_neurons_[idx],
-                                                    self.layers_neurons_[
-                                                        idx + 1]))
+                                    torch.nn.Linear(layer, self.layers_neurons_encoder_[idx + 1]))
+            # create the activation
             self.encoder.add_module(self.hidden_activation + str(idx),
                                     self.activation)
+            # create a dropout layer
             self.encoder.add_module("dropout" + str(idx),
                                     torch.nn.Dropout(dropout_rate))
 
-        for idx, layer in enumerate(self.layers_neurons_[:-1]):
+        # fill the decoder layer
+        for idx, layer in enumerate(self.layers_neurons_decoder_[:-1]):
+
+            # create a batch norm per layer if wanted
             if batch_norm:
                 self.decoder.add_module("batch_norm" + str(idx),
-                                        nn.BatchNorm1d(
-                                            self.layers_neurons_decoder_[idx]))
-            self.decoder.add_module("linear" + str(idx), torch.nn.Linear(
-                self.layers_neurons_decoder_[idx],
-                self.layers_neurons_decoder_[idx + 1]))
+                                        nn.BatchNorm1d(layer))
+
+            # create a linear layer of neurons
+            self.decoder.add_module("linear" + str(idx),
+                                    torch.nn.Linear(layer, self.layers_neurons_decoder_[idx + 1]))
+            # create the activation
             self.encoder.add_module(self.hidden_activation + str(idx),
                                     self.activation)
+            # create a dropout layer
             self.decoder.add_module("dropout" + str(idx),
                                     torch.nn.Dropout(dropout_rate))
 
@@ -294,7 +311,7 @@ class AutoEncoder(BaseDetector):
                                                    shuffle=True)
 
         # initialize the model
-        self.model = inner_autoencoder(
+        self.model = InnerAutoencoder(
             n_features=n_features,
             hidden_neurons=self.hidden_neurons,
             dropout_rate=self.dropout_rate,

--- a/pyod/models/auto_encoder_torch.py
+++ b/pyod/models/auto_encoder_torch.py
@@ -63,7 +63,6 @@ class InnerAutoencoder(nn.Module):
 
         # create the dimensions for the input and hidden layers
         self.layers_neurons_encoder_ = [self.n_features, *hidden_neurons]
-        print(self.layers_neurons_encoder_)
         self.layers_neurons_decoder_ = self.layers_neurons_encoder_[::-1]
 
         # get the object for the activations functions


### PR DESCRIPTION
This Pullrequest is a proposal to fix #434.

I refactored the setup of the Autoencoder (PyTorch Version) in order to address the points of #434. The order of layers is now consistent with the Tensorflow implementation.

The order of Neurons->BatchNorm->Activation follows the Standard-Implementation of [ResNet](https://arxiv.org/abs/1512.03385)

> We adopt batch normalization (BN) [16] right after each convolution and before activation, following [16].

The printed Network now looks like:

<Details>

```
AutoEncoder(batch_norm=True, batch_size=32, contamination=0.1,
      device=device(type='cpu'), dropout_rate=0.2, epochs=10,
      hidden_activation='relu', hidden_neurons=[64, 32],
      learning_rate=0.001, loss_fn=MSELoss(), preprocessing=True,
      weight_decay=1e-05)
InnerAutoencoder(
  (activation): ReLU()
  (encoder): Sequential(
    (linear0): Linear(in_features=300, out_features=64, bias=True)
    (batch_norm0): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
    (relu0): ReLU()
    (dropout0): Dropout(p=0.2, inplace=False)
    (linear1): Linear(in_features=64, out_features=32, bias=True)
    (batch_norm1): BatchNorm1d(32, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
    (relu1): ReLU()
    (dropout1): Dropout(p=0.2, inplace=False)
  )
  (decoder): Sequential(
    (linear0): Linear(in_features=32, out_features=64, bias=True)
    (batch_norm0): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
    (relu0): ReLU()
    (dropout0): Dropout(p=0.2, inplace=False)
    (linear1): Linear(in_features=64, out_features=300, bias=True)
    (relu1): ReLU()
  )
)
```

</Details>

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.
