### PR TITLE
fix anogan plot_learning_curves label issue.

### DIFF
--- a/pyod/models/alad.py
+++ b/pyod/models/alad.py
@@ -449,7 +449,7 @@ class ALAD(BaseDetector):
         ax.plot(range(len(l_gen)), l_gen, )
         ax.set_title('Generator')
         ax.set_ylabel('Loss')
-        ax.set_ylabel('Iter')
+        ax.set_xlabel('Iter')
 
         ax = fig.add_subplot(1, 2, 2)
         ax.plot(range(len(l_disc)), l_disc)

--- a/pyod/models/anogan.py
+++ b/pyod/models/anogan.py
@@ -211,7 +211,7 @@ class AnoGAN(BaseDetector):
         ax.plot(range(len(l_gen)), l_gen, )
         ax.set_title('Generator')
         ax.set_ylabel('Loss')
-        ax.set_ylabel('Iter')
+        ax.set_xlabel('Iter')
 
         ax = fig.add_subplot(1, 2, 2)
         ax.plot(range(len(l_disc)), l_disc)


### PR DESCRIPTION
Currently the y-label is overwritten and says 'Iter' instead of 'Loss'. This is a simple one line replacement to fix the plot labels for Anogan's plot_learning_curves plot.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

