### PR TITLE
check_array added to fit in iforest and ecod

### DIFF
--- a/pyod/models/ecod.py
+++ b/pyod/models/ecod.py
@@ -138,6 +138,7 @@ class ECOD(BaseDetector):
             The anomaly score of the input samples.
         """
         # use multi-thread execution
+        X = check_array(X)
         if self.n_jobs != 1:
             return self._decision_function_parallel(X)
         if hasattr(self, 'X_train'):

--- a/pyod/models/iforest.py
+++ b/pyod/models/iforest.py
@@ -258,7 +258,7 @@ class IForest(BaseDetector):
         """
         check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
         # invert outlier scores. Outliers comes with higher outlier scores
-        return invert_order(self.detector_.decision_function(X))
+        return invert_order(self.detector_.decision_function(check_array(X)))
 
     @property
     def estimators_(self):


### PR DESCRIPTION
Hey,


For iforest models fitted with pandas Dataframes and then scored with decision_function() on pandas DataFrames, the following warning pops up:

xxxx/site-packages/sklearn/base.py:402: UserWarning: X has feature names, but IsolationForest was fitted without feature names

I have added very simple scikit learn utils check_array() to X in decision_function() to iforest (and ecod) models to suppress the warning.


### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.
