### PR TITLE
Fix layer count in autoencoder detector

### DIFF
--- a/pyod/models/auto_encoder.py
+++ b/pyod/models/auto_encoder.py
@@ -178,7 +178,7 @@ class AutoEncoder(BaseDetector):
         model.add(Dropout(self.dropout_rate))
 
         # Additional layers
-        for i, hidden_neurons in enumerate(self.hidden_neurons_, 1):
+        for hidden_neurons in self.hidden_neurons_[1:]:
             model.add(Dense(
                 hidden_neurons,
                 activation=self.hidden_activation,

--- a/pyod/test/test_auto_encoder.py
+++ b/pyod/test/test_auto_encoder.py
@@ -120,6 +120,14 @@ class TestAutoEncoder(unittest.TestCase):
     def test_model_clone(self):
         # for deep models this may not apply
         clone_clf = clone(self.clf)
+    
+    def test_layer_count(self):
+        hidden_layers = len(self.clf.hidden_neurons)
+        # add one to account for the dropout after the input layer
+        dropout_layers = hidden_layers + 1
+        # add two for the input and output layers
+        expected_layer_count = hidden_layers + dropout_layers + 2
+        assert(len(self.clf.model_.layers) == expected_layer_count)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Resolves #138
Resolves #146 
Resolves #254

This PR fixes a problem with the number of layers in the `AutoEncoder` detector. In the current `master`, the input layer is duplicated due to a bug in the loop where the hidden layers are added. The issue is fixed here. I have also added a test to ensure that the number of layers matches expectations.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.
