### PR TITLE
predict_proba inf error

### DIFF
--- a/pyod/models/base.py
+++ b/pyod/models/base.py
@@ -216,7 +216,7 @@ class BaseDetector(object):
         train_scores = self.decision_scores_
 
         test_scores = self.decision_function(X)
-
+        test_scores[test_scores==np.inf]=np.finfo(np.float64).max
         probs = np.zeros([X.shape[0], int(self._classes)])
         if method == 'linear':
             scaler = MinMaxScaler().fit(train_scores.reshape(-1, 1))


### PR DESCRIPTION
The inf value from the models was giving this error (valueerror: input contains infinity or a value too large for dtype('float64')) due to the minmaxscaler in the predict_proba function. to fix the problem i assigned max float64 value instead of inf.


### All Submissions Basics:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Model Submissions:

* [ ] Have you created a <NewModel>.py in ~/pyod/models/?
* [ ] Have you created a <NewModel>_example.py in ~/examples/?
* [ ] Have you created a test_<NewModel>.py in ~/pyod/test/?
* [ ] Have you lint your code locally prior to submission?
