### PR TITLE
Fixing pdf link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,7 +73,7 @@ Welcome to PyOD, a versatile Python library for detecting anomalies in multivari
 
 * **For graph outlier detection**, please use `PyGOD <https://pygod.org/>`_.
 
-* **Performance Comparison \& Datasets**: We have a 45-page, the most comprehensive `anomaly detection benchmark paper <https://www.andrew.cmu.edu/user/yuezhao2/papers/22-neurips-adbench.pdf>`_. The fully `open-sourced ADBench <https://github.com/Minqi824/ADBench>`_ compares 30 anomaly detection algorithms on 57 benchmark datasets.
+* **Performance Comparison \& Datasets**: We have a 45-page, the most comprehensive `anomaly detection benchmark paper <https://arxiv.org/pdf/2206.09426>`_. The fully `open-sourced ADBench <https://github.com/Minqi824/ADBench>`_ compares 30 anomaly detection algorithms on 57 benchmark datasets.
 
 * **Learn more about anomaly detection** \@ `Anomaly Detection Resources <https://github.com/yzhao062/anomaly-detection-resources>`_
 


### PR DESCRIPTION
It seems this pdf link was 404'd and so I found the same pdf on arxiv. You can confirm the pdf is the same through the wayback machine https://web.archive.org/web/20221101105425/https://www.andrew.cmu.edu/user/yuezhao2/papers/22-neurips-adbench.pdf

### All Submissions Basics:

* [ ] Have you followed the guidelines in our Contributing document? - No, this doesn't seem to exist.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
