### PR TITLE
make readme badges be on one line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,55 +3,57 @@ Python Outlier Detection (PyOD)
 
 **Deployment & Documentation & Stats & License**
 
-.. image:: https://img.shields.io/pypi/v/pyod.svg?color=brightgreen
+|badge_pypi| |badge_anaconda| |badge_docs| |badge_stars| |badge_forks| |badge_downloads| |badge_testing| |badge_coverage| |badge_maintainability| |badge_licence| |badge_benchmark|
+
+.. |badge_pypi| image:: https://img.shields.io/pypi/v/pyod.svg?color=brightgreen
    :target: https://pypi.org/project/pyod/
    :alt: PyPI version
 
 
-.. image:: https://anaconda.org/conda-forge/pyod/badges/version.svg
+.. |badge_anaconda| image:: https://anaconda.org/conda-forge/pyod/badges/version.svg
    :target: https://anaconda.org/conda-forge/pyod
    :alt: Anaconda version
 
 
-.. image:: https://readthedocs.org/projects/pyod/badge/?version=latest
+.. |badge_docs| image:: https://readthedocs.org/projects/pyod/badge/?version=latest
    :target: https://pyod.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation status
 
 
-.. image:: https://img.shields.io/github/stars/yzhao062/pyod.svg
+.. |badge_stars| image:: https://img.shields.io/github/stars/yzhao062/pyod.svg
    :target: https://github.com/yzhao062/pyod/stargazers
    :alt: GitHub stars
 
 
-.. image:: https://img.shields.io/github/forks/yzhao062/pyod.svg?color=blue
+.. |badge_forks| image:: https://img.shields.io/github/forks/yzhao062/pyod.svg?color=blue
    :target: https://github.com/yzhao062/pyod/network
    :alt: GitHub forks
 
 
-.. image:: https://pepy.tech/badge/pyod
+.. |badge_downloads| image:: https://pepy.tech/badge/pyod
    :target: https://pepy.tech/project/pyod
    :alt: Downloads
 
-.. image:: https://github.com/yzhao062/pyod/actions/workflows/testing.yml/badge.svg
+.. |badge_testing| image:: https://github.com/yzhao062/pyod/actions/workflows/testing.yml/badge.svg
    :target: https://github.com/yzhao062/pyod/actions/workflows/testing.yml
    :alt: testing
 
 
-.. image:: https://coveralls.io/repos/github/yzhao062/pyod/badge.svg
+.. |badge_coverage| image:: https://coveralls.io/repos/github/yzhao062/pyod/badge.svg
    :target: https://coveralls.io/github/yzhao062/pyod
    :alt: Coverage Status
 
 
-.. image:: https://api.codeclimate.com/v1/badges/bdc3d8d0454274c753c4/maintainability
+.. |badge_maintainability| image:: https://api.codeclimate.com/v1/badges/bdc3d8d0454274c753c4/maintainability
    :target: https://codeclimate.com/github/yzhao062/Pyod/maintainability
    :alt: Maintainability
 
 
-.. image:: https://img.shields.io/github/license/yzhao062/pyod.svg
+.. |badge_license| image:: https://img.shields.io/github/license/yzhao062/pyod.svg
    :target: https://github.com/yzhao062/pyod/blob/master/LICENSE
    :alt: License
 
-.. image:: https://img.shields.io/badge/ADBench-benchmark_results-pink
+.. |badge_benchmark| image:: https://img.shields.io/badge/ADBench-benchmark_results-pink
    :target: https://github.com/Minqi824/ADBench
    :alt: Benchmark
 


### PR DESCRIPTION
Just a small PR to make the readme badges be on one line.

I was just sharing with a colleague and noticed the badges seem to each be on thier own line in the github readme. Thought could be an easy one for me to try see if can make a little prettier potentially as i love the project.

Can quickly see how it will look here: https://github.com/andrewm4894/pyod/blob/patch-1/README.rst

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Model Submissions:

* [ ] Have you created a <NewModel>.py in ~/pyod/models/?
* [ ] Have you created a <NewModel>_example.py in ~/examples/?
* [ ] Have you created a test_<NewModel>.py in ~/pyod/test/?
* [ ] Have you lint your code locally prior to submission?
