### PR TITLE
Fix novelty parameter default value

### DIFF
--- a/pyod/models/lof.py
+++ b/pyod/models/lof.py
@@ -139,7 +139,7 @@ class LOF(BaseDetector):
 
     def __init__(self, n_neighbors=20, algorithm='auto', leaf_size=30,
                  metric='minkowski', p=2, metric_params=None,
-                 contamination=0.1, n_jobs=1, novelty=True):
+                 contamination=0.1, n_jobs=1, novelty=False):
         super(LOF, self).__init__(contamination=contamination)
         self.n_neighbors = n_neighbors
         self.algorithm = algorithm


### PR DESCRIPTION
The LOF wrapper is using the wrong default value for the `novelty` parameter. As per the [scikit-learn docs](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.LocalOutlierFactor.html) and the [docstring](https://github.com/yzhao062/pyod/blob/94887ee86a7d3aac1838e686d6324b91607076c8/pyod/models/lof.py#L110-L115), it should be set to False.