### PR TITLE
Add pyod.__version__ property

### DIFF
--- a/pyod/__init__.py
+++ b/pyod/__init__.py
@@ -2,6 +2,6 @@
 
 from . import models
 from . import utils
-# TODO: add version information here
+from .version import __version__
 
-__all__ = ['models', 'utils']
+__all__ = ['models', 'utils', '__version__']


### PR DESCRIPTION
PyOD has no `pyod.__version__` property, which makes integrating it in other packages complicated. Many tools use `<module>.__version__` to check compatibility at runtime.

PyOD already stores the version number in code, but in a non-standard location (`pyod.version.__version__`). This PR just pulls the `__version__` in the module's global namespace.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
      There is #295, which is open for 3 years and entirely changes the versioning of PyOD.
      In contrast, this PR is a minor change.
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?
      Fixes #253
