### PR TITLE
Add pyproject.toml, replace deprecated sdist command

### DIFF
--- a/pypi_build_commands.txt
+++ b/pypi_build_commands.txt
@@ -1,6 +1,6 @@
 # This is a command list for building pypi packages
 
-python setup.py sdist
+python -m build -s
 twine check dist/*
 
 # docstring check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["setuptools >= 38.6.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyod"
+dynamic = ["version"]
+dependencies = [
+  "joblib",
+  "matplotlib",
+  "numpy>=1.19",
+  "numba>=0.51",
+  "scipy>=1.5.1",
+  "scikit-learn>=0.22.0",
+]
+requires-python = ">=3.6"
+authors = [
+  {name = "Yue Zhao", email = "yzhao062@gmail.com"}
+]
+maintainers = [
+  {name = "Yue Zhao", email = "yzhao062@gmail.com"}
+]
+description = "A Comprehensive and Scalable Python Library for Outlier Detection (Anomaly Detection)"
+readme = "README.rst"
+license = {file = "LICENSE"}
+keywords = ['outlier detection', 'anomaly detection', 'outlier ensembles',
+	'data mining', 'neural networks']
+classifiers = [
+	'Development Status :: 6 - Mature',
+        'Intended Audience :: Education',
+        'Intended Audience :: Financial and Insurance Industry',
+        'Intended Audience :: Science/Research',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+]
+
+[project.optional-dependencies]
+combo = ["combo"]
+pytorch = ["torch"]
+suod = ["suod"]
+xgboost = ["xgboost"]
+pythresh = ["pythresh"]
+
+[project.urls]
+Homepage = "https://github.com/yzhao062/pyod"
+Documentation = "https://pyod.readthedocs.io/"
+Repository = "https://github.com/yzhao062/pyod.git"
+"Bug Tracker" = "https://github.com/yzhao062/pyod/issues"
+Changelog = "https://github.com/yzhao062/pyod/blob/master/CHANGES.txt"
+
+[tool.setuptools.dynamic]
+version = {attr = "pyod.version.__version__"}
+


### PR DESCRIPTION
Copy project metadata to pyproject.toml (PEP 621), replace deprecated `python setup.py sdist` with `python -m build -s`.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Model Submissions:

* [ ] Have you created a <NewModel>.py in ~/pyod/models/?
* [ ] Have you created a <NewModel>_example.py in ~/examples/?
* [ ] Have you created a test_<NewModel>.py in ~/pyod/test/?
* [ ] Have you lint your code locally prior to submission?
