### PR TITLE
Remove deprecated fit_predict & fit_predict_score

### DIFF
--- a/pyod/models/base.py
+++ b/pyod/models/base.py
@@ -16,7 +16,6 @@ from scipy.special import erf
 from scipy.stats import binom
 from sklearn.metrics import roc_auc_score
 from sklearn.preprocessing import MinMaxScaler
-from sklearn.utils import deprecated
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_is_fitted
 from scipy.optimize import root_scalar
@@ -107,35 +106,6 @@ class BaseDetector(metaclass=abc.ABCMeta):
             The anomaly score of the input samples.
         """
         pass
-
-    @deprecated()
-    def fit_predict(self, X, y=None):
-        """Fit detector first and then predict whether a particular sample
-        is an outlier or not. y is ignored in unsupervised models.
-
-        Parameters
-        ----------
-        X : numpy array of shape (n_samples, n_features)
-            The input samples.
-
-        y : Ignored
-            Not used, present for API consistency by convention.
-
-        Returns
-        -------
-        outlier_labels : numpy array of shape (n_samples,)
-            For each observation, tells whether
-            it should be considered as an outlier according to the
-            fitted model. 0 stands for inliers and 1 for outliers.
-
-        .. deprecated:: 0.6.9
-          `fit_predict` will be removed in pyod 0.8.0.; it will be
-          replaced by calling `fit` function first and then accessing
-          `labels_` attribute for consistency.
-        """
-
-        self.fit(X, y)
-        return self.labels_
 
     def predict(self, X, return_confidence=False):
         """Predict if a particular sample is an outlier or not.
@@ -487,51 +457,6 @@ class BaseDetector(metaclass=abc.ABCMeta):
             # return normalized ranks
             ranks = ranks / ranks.max()
         return ranks
-
-    @deprecated()
-    def fit_predict_score(self, X, y, scoring='roc_auc_score'):
-        """Fit the detector, predict on samples, and evaluate the model by
-        predefined metrics, e.g., ROC.
-
-        Parameters
-        ----------
-        X : numpy array of shape (n_samples, n_features)
-            The input samples.
-
-        y : Ignored
-            Not used, present for API consistency by convention.
-
-        scoring : str, optional (default='roc_auc_score')
-            Evaluation metric:
-
-            - 'roc_auc_score': ROC score
-            - 'prc_n_score': Precision @ rank n score
-
-        Returns
-        -------
-        score : float
-
-        .. deprecated:: 0.6.9
-          `fit_predict_score` will be removed in pyod 0.8.0.; it will be
-          replaced by calling `fit` function first and then accessing
-          `labels_` attribute for consistency. Scoring could be done by
-          calling an evaluation method, e.g., AUC ROC.
-        """
-
-        self.fit(X)
-
-        if scoring == 'roc_auc_score':
-            score = roc_auc_score(y, self.decision_scores_)
-        elif scoring == 'prc_n_score':
-            score = precision_n_scores(y, self.decision_scores_)
-        else:
-            raise NotImplementedError('PyOD built-in scoring only supports '
-                                      'ROC and Precision @ rank n')
-
-        print("{metric}: {score}".format(metric=scoring, score=score))
-
-        return score
-
 
     def _set_n_classes(self, y):
         """Set the number of classes if `y` is presented, which is not

--- a/pyod/test/test_abod.py
+++ b/pyod/test/test_abod.py
@@ -118,20 +118,6 @@ class TestFastABOD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 
@@ -215,20 +201,6 @@ class TestABOD(unittest.TestCase):
         assert_equal(confidence.shape, self.y_test.shape)
         assert (confidence.min() >= 0)
         assert (confidence.max() <= 1)
-
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
 
     # def test_score(self):
     #     self.clf.score(self.X_test, self.y_test)

--- a/pyod/test/test_ae1svm.py
+++ b/pyod/test/test_ae1svm.py
@@ -98,10 +98,6 @@ class TestAE1SVM(unittest.TestCase):
         assert confidence.min() >= 0
         assert confidence.max() <= 1
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
     def test_prediction_with_rejection(self):
         pred_labels = self.clf.predict_with_rejection(self.X_test,
                                                       return_stats=False)
@@ -116,16 +112,6 @@ class TestAE1SVM(unittest.TestCase):
         assert (ub_rejrate >= 0)
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
 
     def test_model_clone(self):
         # for deep models this may not apply

--- a/pyod/test/test_alad.py
+++ b/pyod/test/test_alad.py
@@ -134,20 +134,6 @@ class TestALAD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_prediction_scores_with_sigmoid(self):
         self.alad = ALAD(activation_hidden_gen='sigmoid',
                          activation_hidden_disc='sigmoid')

--- a/pyod/test/test_auto_encoder.py
+++ b/pyod/test/test_auto_encoder.py
@@ -114,19 +114,6 @@ class TestAutoEncoder(unittest.TestCase):
         self.assertLessEqual(ub_rejrate, 1)
         self.assertGreaterEqual(ub_cost, 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        self.assertEqual(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        self.assertRaises(NotImplementedError, self.clf.fit_predict_score,
-                          self.X_test, self.y_test, scoring='something')
-
     def tearDown(self):
         pass
 

--- a/pyod/test/test_base.py
+++ b/pyod/test/test_base.py
@@ -157,13 +157,6 @@ class TestBASE(unittest.TestCase):
         self.dummy_clf = Dummy2()
         assert_equal(self.dummy_clf.fit(0), 0)
 
-    def test_fit_predict(self):
-        # TODO: add more testcases
-
-        self.dummy_clf = Dummy3()
-
-        assert_equal(self.dummy_clf.fit_predict(0), 0)
-
     def test_predict_proba(self):
         # TODO: create uniform testcases
         pass

--- a/pyod/test/test_cblof.py
+++ b/pyod/test/test_cblof.py
@@ -131,20 +131,6 @@ class TestCBLOF(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_cof.py
+++ b/pyod/test/test_cof.py
@@ -114,20 +114,6 @@ class TestFastCOF(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)
@@ -222,20 +208,6 @@ class TestMemoryCOF(unittest.TestCase):
     def test_prediction_proba_parameter(self):
         with assert_raises(ValueError):
             self.clf.predict_proba(self.X_test, method='something')
-
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
 
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)

--- a/pyod/test/test_copod.py
+++ b/pyod/test/test_copod.py
@@ -112,20 +112,6 @@ class TestCOPOD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_copod_parallel.py
+++ b/pyod/test/test_copod_parallel.py
@@ -124,20 +124,6 @@ class TestCOPODParallel(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_deepsvdd.py
+++ b/pyod/test/test_deepsvdd.py
@@ -126,20 +126,6 @@ class TestDeepSVDD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         clone_clf = clone(self.clf)
         clone_clf = clone(self.clf_ae)

--- a/pyod/test/test_devnet.py
+++ b/pyod/test/test_devnet.py
@@ -120,20 +120,6 @@ class TestDevNet(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train, self.y_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         pass
         # clone_clf = clone(self.clf)

--- a/pyod/test/test_dif.py
+++ b/pyod/test/test_dif.py
@@ -117,20 +117,6 @@ class TestDIF(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         pass
 

--- a/pyod/test/test_ecod.py
+++ b/pyod/test/test_ecod.py
@@ -112,20 +112,6 @@ class TestECOD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)
@@ -237,20 +223,6 @@ class TestECODParallel(unittest.TestCase):
         assert_equal(confidence.shape, self.y_test.shape)
         assert (confidence.min() >= 0)
         assert (confidence.max() <= 1)
-
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
 
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)

--- a/pyod/test/test_ecod_parallel.py
+++ b/pyod/test/test_ecod_parallel.py
@@ -124,20 +124,6 @@ class TestCOPODParallel(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_feature_bagging.py
+++ b/pyod/test/test_feature_bagging.py
@@ -120,20 +120,6 @@ class TestFeatureBagging(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_hbos.py
+++ b/pyod/test/test_hbos.py
@@ -101,20 +101,6 @@ class TestHBOS(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     # def test_score(self):
     #     self.clf.score(self.X_test, self.y_test)
     #     self.clf.score(self.X_test, self.y_test, scoring='roc_auc_score')
@@ -229,20 +215,6 @@ class TestAutoHBOS(unittest.TestCase):
         assert_equal(confidence.shape, self.y_test.shape)
         assert (confidence.min() >= 0)
         assert (confidence.max() <= 1)
-
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
 
     # def test_score(self):
     #     self.clf.score(self.X_test, self.y_test)

--- a/pyod/test/test_iforest.py
+++ b/pyod/test/test_iforest.py
@@ -128,20 +128,6 @@ class TestIForest(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_inne.py
+++ b/pyod/test/test_inne.py
@@ -118,20 +118,6 @@ class TestINNE(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_kde.py
+++ b/pyod/test/test_kde.py
@@ -116,20 +116,6 @@ class TestKDE(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="roc_auc_score")
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="prc_n_score")
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring="something")
-
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_knn.py
+++ b/pyod/test/test_knn.py
@@ -103,20 +103,6 @@ class TestKnn(unittest.TestCase):
         assert (confidence.min() >= 0)
         assert (confidence.max() <= 1)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)
@@ -295,20 +281,6 @@ class TestKnnMahalanobis(unittest.TestCase):
         assert (ub_rejrate >= 0)
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
-
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
 
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)

--- a/pyod/test/test_kpca.py
+++ b/pyod/test/test_kpca.py
@@ -113,20 +113,6 @@ class TestKPCA(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="roc_auc_score")
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="prc_n_score")
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring="something")
-
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 

--- a/pyod/test/test_lmdd.py
+++ b/pyod/test/test_lmdd.py
@@ -119,20 +119,6 @@ class TestCOF(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_check_parameters(self):
         with assert_raises(ValueError):
             LMDD(contamination=10.)

--- a/pyod/test/test_loci.py
+++ b/pyod/test/test_loci.py
@@ -113,20 +113,6 @@ class TestLOCI(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_loda.py
+++ b/pyod/test/test_loda.py
@@ -115,20 +115,6 @@ class TestLODA(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 
@@ -197,20 +183,6 @@ class TestAutoLODA(unittest.TestCase):
     def test_prediction_proba_parameter(self):
         with assert_raises(ValueError):
             self.clf.predict_proba(self.X_test, method='something')
-
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
 
     def test_model_clone(self):
         clone_clf = clone(self.clf)

--- a/pyod/test/test_lof.py
+++ b/pyod/test/test_lof.py
@@ -118,20 +118,6 @@ class TestLOF(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_lscp.py
+++ b/pyod/test/test_lscp.py
@@ -140,20 +140,6 @@ class TestLSCP(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_lunar.py
+++ b/pyod/test/test_lunar.py
@@ -115,20 +115,6 @@ class TestLUNAR(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_mad.py
+++ b/pyod/test/test_mad.py
@@ -128,28 +128,6 @@ class TestMAD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_with_nan(self):
-        pred_labels = self.clf_nan.fit_predict(self.X_train_nan)
-        assert_equal(pred_labels.shape, self.y_train_nan.shape)
-
-    def test_fit_predict_with_inf(self):
-        pred_labels = self.clf_inf.fit_predict(self.X_train_inf)
-        assert_equal(pred_labels.shape, self.y_train_inf.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_mcd.py
+++ b/pyod/test/test_mcd.py
@@ -130,20 +130,6 @@ class TestMCD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_mo_gaal.py
+++ b/pyod/test/test_mo_gaal.py
@@ -124,20 +124,6 @@ class TestMO_GAAL(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 

--- a/pyod/test/test_ocsvm.py
+++ b/pyod/test/test_ocsvm.py
@@ -128,20 +128,6 @@ class TestOCSVM(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_pca.py
+++ b/pyod/test/test_pca.py
@@ -121,20 +121,6 @@ class TestPCA(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_qmcd.py
+++ b/pyod/test/test_qmcd.py
@@ -119,20 +119,6 @@ class TestQMCD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="roc_auc_score")
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="prc_n_score")
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring="something")
-
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_rgraph.py
+++ b/pyod/test/test_rgraph.py
@@ -126,20 +126,6 @@ class TestRGraph(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         # for deep models this may not apply
         clone_clf = clone(self.clf)

--- a/pyod/test/test_rod.py
+++ b/pyod/test/test_rod.py
@@ -102,20 +102,6 @@ class TestROD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_sampling.py
+++ b/pyod/test/test_sampling.py
@@ -119,20 +119,6 @@ class TestSampling(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="roc_auc_score")
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="prc_n_score")
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring="something")
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_so_gaal.py
+++ b/pyod/test/test_so_gaal.py
@@ -122,20 +122,6 @@ class TestSO_GAAL(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 

--- a/pyod/test/test_so_gaal_new.py
+++ b/pyod/test/test_so_gaal_new.py
@@ -115,19 +115,6 @@ class TestSO_GAAL(unittest.TestCase):
         self.assertLessEqual(ub_rejrate, 1)
         self.assertGreaterEqual(ub_cost, 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        self.assertEqual(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        self.assertRaises(NotImplementedError, self.clf.fit_predict_score,
-                          self.X_test, self.y_test, scoring='something')
-
     def tearDown(self):
         pass
 

--- a/pyod/test/test_sod.py
+++ b/pyod/test/test_sod.py
@@ -140,20 +140,6 @@ class TestSOD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_sos.py
+++ b/pyod/test/test_sos.py
@@ -113,20 +113,6 @@ class TestSOS(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     def test_predict_rank(self):
         pred_socres = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_suod.py
+++ b/pyod/test/test_suod.py
@@ -139,20 +139,6 @@ class TestSUOD(unittest.TestCase):
         assert (ub_rejrate <= 1)
         assert (ub_cost >= 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring='something')
-
     # def test_predict_rank(self):
     #     pred_socres = self.clf.decision_function(self.X_test)
     #     pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_thresholds.py
+++ b/pyod/test/test_thresholds.py
@@ -131,22 +131,6 @@ class TestThresholds(unittest.TestCase):
         assert confidence.max() <= 1
 
     @unittest.skipIf(not py_ver, 'Python 3.6 not included')
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        assert_equal(pred_labels.shape, self.y_train.shape)
-
-    @unittest.skipIf(not py_ver, 'Python 3.6 not included')
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="roc_auc_score")
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring="prc_n_score")
-        with assert_raises(NotImplementedError):
-            self.clf.fit_predict_score(self.X_test, self.y_test,
-                                       scoring="something")
-
-    @unittest.skipIf(not py_ver, 'Python 3.6 not included')
     def test_predict_rank(self):
         pred_scores = self.clf.decision_function(self.X_test)
         pred_ranks = self.clf._predict_rank(self.X_test)

--- a/pyod/test/test_vae.py
+++ b/pyod/test/test_vae.py
@@ -113,19 +113,6 @@ class TestVAE(unittest.TestCase):
         self.assertLessEqual(ub_rejrate, 1)
         self.assertGreaterEqual(ub_cost, 0)
 
-    def test_fit_predict(self):
-        pred_labels = self.clf.fit_predict(self.X_train)
-        self.assertEqual(pred_labels.shape, self.y_train.shape)
-
-    def test_fit_predict_score(self):
-        self.clf.fit_predict_score(self.X_test, self.y_test)
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='roc_auc_score')
-        self.clf.fit_predict_score(self.X_test, self.y_test,
-                                   scoring='prc_n_score')
-        self.assertRaises(NotImplementedError, self.clf.fit_predict_score,
-                          self.X_test, self.y_test, scoring='something')
-
     def tearDown(self):
         pass
 


### PR DESCRIPTION
Remove deprecated `fit_predict` & `fit_predict_score` from `BaseDetector` class and all the corresponding tests. These methods were marked as deprecated in version 0.6.9 and were expected to be removed in version 0.8.0.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
