### PR TITLE
publish wheels

### DIFF
--- a/pypi_build_commands.txt
+++ b/pypi_build_commands.txt
@@ -1,6 +1,6 @@
 # This is a command list for building pypi packages
 
-python setup.py sdist
+python -m build
 twine check dist/*
 
 # docstring check


### PR DESCRIPTION
- direct invocation of setup.py is deprecated
- publish wheels, rather than making every consumer of the package build a wheel

Before `python -m build` you may need to `pip install build` or equivalent (just as you need to install twine before running twine).