### PR TITLE
Change deprecated property name for setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
This fixes the install error happening on setuptools 0.78: `setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.`

Closes https://github.com/yzhao062/pyod/issues/630

### All Submissions Basics:

* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Model Submissions:

* [ ] Have you created a <NewModel>.py in ~/pyod/models/?
* [ ] Have you created a <NewModel>_example.py in ~/examples/?
* [ ] Have you created a test_<NewModel>.py in ~/pyod/test/?
* [ ] Have you lint your code locally prior to submission?
