### PR TITLE
Harden model_analysis_jsons package-data config and add sdist regression test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ prune pyod/test
 prune README.md
 include README.rst
 include requirements.txt
+graft pyod/utils/model_analysis_jsons
 recursive-include pyod/utils/model_analysis_jsons *.json

--- a/pyod/test/test_package_data.py
+++ b/pyod/test/test_package_data.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestPackageData(unittest.TestCase):
+    def test_model_analysis_jsons_are_in_sdist(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        source_dir = repo_root / "pyod" / "utils" / "model_analysis_jsons"
+        self.assertTrue(source_dir.exists())
+        self.assertTrue(any(source_dir.glob("*.json")))
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dist_dir = Path(tmp_dir) / "dist"
+            dist_dir.mkdir(parents=True, exist_ok=True)
+
+            subprocess.check_call(
+                [sys.executable, "setup.py", "sdist", "--dist-dir", str(dist_dir)],
+                cwd=str(repo_root),
+            )
+
+            archives = sorted(dist_dir.glob("*.tar.gz"))
+            self.assertTrue(archives, "sdist archive was not created")
+
+            with tarfile.open(archives[0], "r:gz") as archive:
+                members = archive.getnames()
+
+            has_model_json = any(
+                member.endswith(".json")
+                and os.path.normpath(member).replace("\\", "/").find(
+                    "/pyod/utils/model_analysis_jsons/"
+                )
+                != -1
+                for member in members
+            )
+            self.assertTrue(
+                has_model_json,
+                "model_analysis_jsons JSON files are missing from sdist package",
+            )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ setup(
     packages=find_packages(exclude=['test']),
     include_package_data=True,
     package_data={
+        # Keep both patterns to make packaging robust across backends:
+        # one relative to the top-level package and one to pyod.utils.
+        'pyod': ['utils/model_analysis_jsons/*.json'],
         'pyod.utils': ['model_analysis_jsons/*.json'],
     },
     install_requires=requirements,


### PR DESCRIPTION
## Summary
- harden package-data declarations so `model_analysis_jsons` are included via both `pyod` and `pyod.utils` package paths in `setup.py`
- reinforce source distribution inclusion with `graft pyod/utils/model_analysis_jsons` in `MANIFEST.in`
- add a packaging regression test that builds `sdist` and asserts JSON assets are present in the archive

## Why
Issue #642 reports missing `model_analysis_jsons` files in installed distributions, which breaks auto model selection at runtime.

## Validation
- `python3 -m pytest pyod/test/test_package_data.py -q`
- `python3 -m py_compile setup.py`

Closes #642