### PR TITLE
Quality: Broken optional dependency handling for PyTorch

### DIFF
--- a/pyod/models/gaal_base.py
+++ b/pyod/models/gaal_base.py
@@ -8,12 +8,10 @@ import math
 
 try:
     import torch
-except ImportError:
-    print('please install torch first')
-
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ImportError as e:
+    raise ImportError('PyTorch is required for GAAL models. Please install it with `pip install torch`.') from e
 
 
 def create_discriminator(latent_size, data_size):


### PR DESCRIPTION
## Problem

`pyod/models/gaal_base.py` tries to handle missing `torch` with a `try/except`, but immediately performs an unconditional `import torch` afterwards. If PyTorch is not installed, the module still crashes at import time, and the printed message is misleading.

**Severity**: `high`
**File**: `pyod/models/gaal_base.py`

## Solution

Remove the second unconditional `import torch` and raise a clear `ImportError` with actionable installation guidance, or gate GAAL-specific code behind lazy imports.

## Changes

- `pyod/models/gaal_base.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
