### PR TITLE
Fix LOF novelty parameter default value: True → False

### DIFF
--- a/pyod/models/lof.py
+++ b/pyod/models/lof.py
@@ -137,7 +137,7 @@ class LOF(BaseDetector):
 
     def __init__(self, n_neighbors=20, algorithm='auto', leaf_size=30,
                  metric='minkowski', p=2, metric_params=None,
-                 contamination=0.1, n_jobs=1, novelty=True):
+                 contamination=0.1, n_jobs=1, novelty=False):
         super(LOF, self).__init__(contamination=contamination)
         self.n_neighbors = n_neighbors
         self.algorithm = algorithm


### PR DESCRIPTION
Good day

Fix the default value of the `novelty` parameter in `pyod.models.lof.LOF.__init__`.

**Issue:** yzhao062/pyod#638

**Problem:**
The docstring correctly states `novelty : bool (default=False)`, but the actual `__init__` signature incorrectly defaults to `novelty=True`. This is inconsistent with scikit-learn's `LocalOutlierFactor` behavior.

**Fix:**
Changed `novelty=True` to `novelty=False` in the `__init__` signature on line 140 of `pyod/models/lof.py`, aligning the implementation with its own documentation and with sklearn conventions.

**Verification:**
- Only 1 line changed (parameter default value)
- No change to any logic or behavior beyond default parameter alignment
- Docstring was already correct; no change needed there

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithOutRoof