### PR TITLE
refactor: decompose ADEngine into private helper modules

### DIFF
--- a/pyod/utils/_detector_factory.py
+++ b/pyod/utils/_detector_factory.py
@@ -1,0 +1,83 @@
+"""Detector construction from ADEngine plans.
+
+Extracted from `pyod.utils.ad_engine.ADEngine` in 2026-05.
+Not part of the public API.
+"""
+# Author: Yue Zhao <yzhao062@gmail.com>
+# License: BSD 2 clause
+
+import importlib
+
+
+def build_detector_from_plan(plan, kb):
+    """Build and return an unfitted detector from a plan.
+
+    Parameters
+    ----------
+    plan : dict (DetectionPlan)
+        Output of plan_detection().
+    kb : KnowledgeBase
+        Knowledge base used to look up algorithm metadata.
+
+    Returns
+    -------
+    detector : BaseDetector
+    """
+    name = plan['detector_name']
+    algo = kb.get_algorithm(name)
+    if algo is None:
+        raise ValueError("Unknown detector '%s'" % name)
+    if algo.get('status') not in ('shipped', 'experimental'):
+        raise ValueError(
+            "Detector '%s' has status '%s' and cannot be built"
+            % (name, algo.get('status', 'unknown')))
+
+    preset = plan.get('preset')
+    if preset:
+        return build_from_preset(name, preset,
+                                 plan.get('params', {}))
+
+    class_path = algo['class_path']
+    module_path, class_name = class_path.rsplit('.', 1)
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, class_name)
+    params = plan.get('params', {})
+    return cls(**params)
+
+
+def build_from_preset(detector_name, preset, extra_params):
+    """Build a detector using a factory preset.
+
+    Presets are class-method factories that wire common defaults for
+    a modality (e.g., text or image). Currently only `EmbeddingOD`
+    exposes presets (``'for_text'``, ``'for_image'``).
+
+    Parameters
+    ----------
+    detector_name : str
+        Class name of the detector. Currently only ``'EmbeddingOD'``
+        is recognized.
+    preset : str
+        Preset name. For ``'EmbeddingOD'``, one of ``'for_text'`` or
+        ``'for_image'``.
+    extra_params : dict
+        Additional kwargs forwarded to the preset class method.
+
+    Returns
+    -------
+    BaseDetector
+        Unfitted detector instance.
+
+    Raises
+    ------
+    ValueError
+        If the (detector_name, preset) pair is not recognized.
+    """
+    if detector_name == 'EmbeddingOD':
+        from pyod.models.embedding import EmbeddingOD
+        if preset == 'for_text':
+            return EmbeddingOD.for_text(**extra_params)
+        elif preset == 'for_image':
+            return EmbeddingOD.for_image(**extra_params)
+    raise ValueError("Unknown preset '%s' for '%s'"
+                     % (preset, detector_name))

--- a/pyod/utils/_kb_router.py
+++ b/pyod/utils/_kb_router.py
@@ -1,0 +1,250 @@
+"""KB rule engine for ADEngine planning.
+
+Extracts the `_evaluate_rules` / `_rule_matches` / `_eval_condition`
+chain plus `_make_plan` and `_suggest_alternative` from
+`pyod.utils.ad_engine.ADEngine` in 2026-05. Not part of the public API.
+"""
+
+
+def evaluate_rules(profile, priority, kb):
+    """Evaluate routing rules against a data profile.
+
+    Walks every rule in the KB's routing-rules table; for each rule
+    whose conditions match the profile, attaches the rule's
+    ``reason`` and ``evidence`` fields to each recommendation as the
+    private keys ``_reason`` and ``_evidence``. When the same
+    detector appears in multiple matched rules, keeps the
+    recommendation with the highest ``confidence``. The final list
+    is sorted by descending confidence.
+
+    Parameters
+    ----------
+    profile : dict
+        Data profile from `profile_data()`. Provides fields like
+        ``'n_samples'``, ``'n_features'``, ``'modality'``, etc.
+    priority : str
+        Caller-supplied priority axis (e.g., ``'speed'``,
+        ``'accuracy'``, ``'memory'``). Matched against rule
+        conditions whose ``field == 'priority'``.
+    kb : KnowledgeBase
+        Knowledge-base instance exposing ``routing_rules``.
+
+    Returns
+    -------
+    list of dict
+        Recommendation dicts sorted by descending confidence. Each
+        dict has keys ``'detector'``, ``'confidence'``, plus rule
+        context under ``'_reason'`` and ``'_evidence'``. Empty when
+        no rule matches.
+    """
+    rules = kb.routing_rules.get('rules', [])
+    all_recs = []
+
+    for rule in rules:
+        if rule_matches(rule, profile, priority):
+            reason = rule.get('reason', '')
+            evidence = rule.get('evidence', [])
+            for rec in rule.get('recommendations', []):
+                enriched = dict(rec)
+                enriched['_reason'] = reason
+                enriched['_evidence'] = evidence
+                all_recs.append(enriched)
+
+    seen = {}
+    for rec in all_recs:
+        name = rec['detector']
+        if name not in seen or \
+                rec.get('confidence', 0) > seen[name].get('confidence', 0):
+            seen[name] = rec
+    return sorted(seen.values(),
+                  key=lambda r: r.get('confidence', 0),
+                  reverse=True)
+
+
+def rule_matches(rule, profile, priority):
+    """Check if all conditions in a rule match the profile.
+
+    Each rule's ``conditions`` list is treated as a logical AND. A
+    condition's ``field`` is read from `priority` when equal to
+    ``'priority'``, otherwise from `profile`. A missing profile field
+    fails the match.
+
+    Parameters
+    ----------
+    rule : dict
+        Rule dict with a ``'conditions'`` list. Each condition has
+        keys ``'field'``, ``'op'``, and ``'value'``.
+    profile : dict
+        Data profile from `profile_data()`.
+    priority : str
+        Caller-supplied priority axis.
+
+    Returns
+    -------
+    bool
+        ``True`` only if every condition evaluates to true and no
+        referenced profile field is missing; ``False`` otherwise.
+    """
+    for cond in rule.get('conditions', []):
+        field = cond['field']
+        op = cond['op']
+        value = cond['value']
+
+        if field == 'priority':
+            actual = priority
+        else:
+            actual = profile.get(field)
+
+        if actual is None:
+            return False
+        if not eval_condition(actual, op, value):
+            return False
+    return True
+
+
+def eval_condition(actual, op, value):
+    """Evaluate a single condition predicate.
+
+    Supported operators: ``'eq'`` (equality), ``'lt'``, ``'lte'``,
+    ``'gt'``, ``'gte'`` (numeric comparisons after `float` coercion),
+    and ``'in'`` (membership test). Unknown operators evaluate to
+    ``False``.
+
+    Parameters
+    ----------
+    actual : object
+        Value taken from the profile or priority.
+    op : str
+        Operator name. One of ``'eq'``, ``'lt'``, ``'lte'``,
+        ``'gt'``, ``'gte'``, ``'in'``.
+    value : object
+        Right-hand operand. For numeric ops, must be coercible to
+        `float`. For ``'in'``, must be a container.
+
+    Returns
+    -------
+    bool
+        Result of the predicate. Returns ``False`` when `op` is not
+        recognized.
+    """
+    if op == 'eq':
+        return actual == value
+    if op == 'lt':
+        return float(actual) < float(value)
+    if op == 'lte':
+        return float(actual) <= float(value)
+    if op == 'gt':
+        return float(actual) > float(value)
+    if op == 'gte':
+        return float(actual) >= float(value)
+    if op == 'in':
+        return actual in value
+    return False
+
+
+def make_plan(detector_name, params=None, preset=None,
+              reason='', evidence=None, confidence=0.5,
+              alternatives=None, note=None):
+    """Construct a closed-schema DetectionPlan dict.
+
+    The closed schema means downstream code can rely on the keys
+    ``'detector_name'``, ``'params'``, ``'reason'``, ``'evidence'``,
+    ``'confidence'``, and ``'alternatives'`` always being present.
+    Optional keys (``'preset'``, ``'note'``) are added only when the
+    caller supplies a non-empty value.
+
+    Parameters
+    ----------
+    detector_name : str
+        Class name of the detector (e.g., ``'IForest'``, ``'KNN'``).
+    params : dict, optional
+        Constructor kwargs for the detector. Defaults to ``{}``.
+    preset : str, optional
+        Factory preset name (e.g., ``'for_text'``). Only included in
+        the returned plan when non-empty.
+    reason : str, optional
+        Human-readable explanation for the choice. Defaults to ``''``.
+    evidence : list, optional
+        Supporting evidence items (rule IDs, profile fields, etc.).
+        Defaults to ``[]``.
+    confidence : float, optional
+        Confidence in the plan, in [0, 1]. Defaults to 0.5.
+    alternatives : list of dict, optional
+        Backup plans, each itself a DetectionPlan dict. Defaults to
+        ``[]``.
+    note : str, optional
+        Free-form note. Only included in the returned plan when
+        non-empty.
+
+    Returns
+    -------
+    dict
+        DetectionPlan dict with closed-schema keys
+        ``'detector_name'``, ``'params'``, ``'reason'``,
+        ``'evidence'``, ``'confidence'``, ``'alternatives'``, and
+        optional ``'preset'`` and ``'note'``.
+    """
+    plan = {
+        'detector_name': detector_name,
+        'params': params or {},
+        'reason': reason,
+        'evidence': evidence or [],
+        'confidence': confidence,
+        'alternatives': alternatives or [],
+    }
+    if preset:
+        plan['preset'] = preset
+    if note:
+        plan['note'] = note
+    return plan
+
+
+def suggest_alternative(result, kb, make_plan_fn):
+    """Suggest an alternative detector different from the current one.
+
+    Resolution order:
+
+    1. First entry in the current plan's ``alternatives`` list whose
+       ``detector_name`` differs from the current detector.
+    2. First detector from a hard-coded fallback chain (``IForest``,
+       ``ECOD``, ``KNN``, ``LOF``, ``HBOS``, ``COPOD``, ``CBLOF``)
+       that is not the current one and is marked ``shipped`` in the
+       knowledge base.
+    3. ``IForest`` as a last-resort default.
+
+    Parameters
+    ----------
+    result : dict
+        Detector result dict containing the current ``'plan'``.
+    kb : KnowledgeBase
+        Knowledge-base instance, used to check algorithm status.
+    make_plan_fn : callable
+        Factory matching the signature of `make_plan`. Called for the
+        fallback-chain and last-resort branches.
+
+    Returns
+    -------
+    dict
+        DetectionPlan dict for an alternative detector.
+    """
+    current = result['plan'].get('detector_name', '')
+
+    alternatives = result['plan'].get('alternatives', [])
+    for alt in alternatives:
+        if alt.get('detector_name') and alt['detector_name'] != current:
+            return alt
+
+    fallback_order = ['IForest', 'ECOD', 'KNN', 'LOF', 'HBOS',
+                      'COPOD', 'CBLOF']
+    for name in fallback_order:
+        if name != current:
+            algo = kb.get_algorithm(name)
+            if algo and algo.get('status') == 'shipped':
+                return make_plan_fn(
+                    detector_name=name, params={},
+                    reason='Alternative to %s' % current,
+                    evidence=[], confidence=0.6)
+
+    return make_plan_fn(
+        detector_name='IForest', params={},
+        reason='Default fallback', evidence=[], confidence=0.5)

--- a/pyod/utils/_nl_feedback.py
+++ b/pyod/utils/_nl_feedback.py
@@ -1,0 +1,237 @@
+"""ADEngine iterate() feedback parsing.
+
+Extracts `_iterate_structured` and `_iterate_nl` from
+`pyod.utils.ad_engine.ADEngine` in 2026-05.
+"""
+
+from .investigation import _make_history_entry
+
+
+def apply_structured_feedback(
+        state, feedback, kb, plan_detection_fn, make_plan_fn):
+    """Handle structured feedback dict.
+
+    Mutates `state` in place to apply the feedback action, then
+    resets detection-side fields (``results``, ``consensus``,
+    ``analysis``, ``quality``) so the next ``run()`` starts clean.
+    Recognized actions:
+
+    - ``'adjust_contamination'``: rewrite the ``contamination``
+      param on every plan to ``feedback['value']``.
+    - ``'exclude'``: drop plans whose detector name appears in
+      ``feedback['detectors']``. Re-plans (with the excluded
+      detectors as a constraint) when the result is empty.
+    - ``'include'``: append plans for detectors in
+      ``feedback['detectors']`` that are not already present, are
+      shipped or experimental in the KB, and fit under the v1 cap of
+      three plans.
+    - ``'rerun'``: keep plans unchanged; signals the agent to run
+      the same plan again.
+
+    Unknown actions set ``next_action`` to ``confirm_with_user`` and
+    return early without resetting detection state.
+
+    Parameters
+    ----------
+    state : InvestigationState
+        Mutable session state. Modified in place.
+    feedback : dict
+        Structured feedback. Must contain ``'action'``; other keys
+        depend on the action.
+    kb : KnowledgeBase
+        Knowledge-base instance, used for algorithm lookup on
+        ``'include'``.
+    plan_detection_fn : callable
+        Planner used for the ``'exclude'`` re-plan branch. Called as
+        ``plan_detection_fn(profile, constraints={...})``.
+    make_plan_fn : callable
+        Factory matching `make_plan`. Called by the ``'include'``
+        branch to build new plans.
+
+    Returns
+    -------
+    InvestigationState
+        The same `state` object, mutated.
+    """
+    action = feedback.get('action', '')
+    state.iteration += 1
+
+    if action == 'adjust_contamination':
+        value = feedback['value']
+        for p in state.plans:
+            params = dict(p.get('params', {}))
+            params['contamination'] = value
+            p['params'] = params
+        detail = 'Adjusted contamination to %.3f' % value
+
+    elif action == 'exclude':
+        to_exclude = set(feedback.get('detectors', []))
+        state.plans = [
+            p for p in state.plans
+            if p['detector_name'] not in to_exclude]
+        if not state.plans:
+            # Re-plan without excluded detectors
+            result = plan_detection_fn(
+                state.profile,
+                constraints={'exclude_detectors': list(to_exclude)})
+            state.plans = [result]
+            for alt in result.get('alternatives', []):
+                if alt.get('detector_name'):
+                    state.plans.append(alt)
+        detail = 'Excluded: %s' % ', '.join(to_exclude)
+
+    elif action == 'include':
+        to_include = feedback.get('detectors', [])
+        existing = {p['detector_name'] for p in state.plans}
+        added, already, capped = [], [], []
+        for name in to_include:
+            if name in existing:
+                already.append(name)
+            elif len(state.plans) >= 3:
+                capped.append(name)
+            else:
+                algo = kb.get_algorithm(name)
+                if algo and algo.get('status') in (
+                        'shipped', 'experimental'):
+                    state.plans.append(make_plan_fn(
+                        detector_name=name, params={},
+                        reason='Added by user', confidence=0.5))
+                    added.append(name)
+        parts = []
+        if added:
+            parts.append('Included: %s' % ', '.join(added))
+        if already:
+            parts.append('Already present: %s'
+                         % ', '.join(already))
+        if capped:
+            parts.append('Could not add %s (v1 cap: 3)'
+                         % ', '.join(capped))
+        detail = '. '.join(parts) if parts else 'No changes'
+
+    elif action == 'rerun':
+        detail = 'Re-running same plan'
+
+    else:
+        state.next_action = {
+            'action': 'confirm_with_user',
+            'reason': 'Unknown action: %s' % action,
+        }
+        return state
+
+    state.phase = 'planned'
+    state.results = []
+    state.consensus = None
+    state.analysis = None
+    state.quality = None
+    state.next_action = {
+        'action': 'run',
+        'reason': 'Plan adjusted. ' + detail,
+        'adjustment': detail,
+    }
+    state.history.append(_make_history_entry(
+        'planned', 'iterate', state.iteration, detail))
+    return state
+
+
+def apply_nl_feedback(
+        state, feedback, kb, plan_detection_fn, make_plan_fn):
+    """Parse natural-language feedback into a structured action.
+
+    Maps a free-text string to a structured-feedback dict using a
+    small set of keyword heuristics, then dispatches to
+    `apply_structured_feedback` when confident.
+
+    - ``'without' | 'exclude'`` plus a known detector name (case
+      insensitive): action ``'exclude'`` with that detector
+      (confidence 0.9). Without a detector match, falls back to an
+      ``'exclude'`` shell with confidence 0.3.
+    - ``'false positive' | 'too many'``: ``'adjust_contamination'``
+      to half the current value, floored at 0.01 (confidence 0.7).
+    - ``'missed' | 'false negative'``: ``'adjust_contamination'`` to
+      1.5 times the current value, capped at 0.5 (confidence 0.7).
+    - ``'rerun' | 'again'``: ``'rerun'`` (confidence 0.9).
+    - Otherwise: ``'rerun'`` with confidence 0.0.
+
+    When confidence is at least 0.8, applies the action immediately
+    via `apply_structured_feedback`. Otherwise sets
+    ``next_action`` to ``confirm_with_user`` so the caller can ask
+    for confirmation and appends an entry to ``state.history``.
+
+    Parameters
+    ----------
+    state : InvestigationState
+        Mutable session state. Modified in place.
+    feedback : str
+        Free-form natural-language feedback from the user.
+    kb : KnowledgeBase
+        Knowledge-base instance, forwarded to
+        `apply_structured_feedback` on high-confidence dispatch.
+    plan_detection_fn : callable
+        Planner forwarded to `apply_structured_feedback`.
+    make_plan_fn : callable
+        Plan factory forwarded to `apply_structured_feedback`.
+
+    Returns
+    -------
+    InvestigationState
+        The same `state` object, mutated.
+    """
+    lower = feedback.lower()
+    proposed = None
+    confidence = 0.0
+
+    # High-confidence patterns
+    if 'without' in lower or 'exclude' in lower:
+        # Try to extract detector name
+        for r in state.results:
+            name = r.get('detector_name', '')
+            if name.lower() in lower:
+                proposed = {'action': 'exclude',
+                            'detectors': [name]}
+                confidence = 0.9
+                break
+        if proposed is None and ('without' in lower
+                                 or 'exclude' in lower):
+            proposed = {'action': 'exclude', 'detectors': []}
+            confidence = 0.3
+
+    elif ('false positive' in lower or 'too many' in lower):
+        current = state.plans[0].get('params', {}).get(
+            'contamination', 0.1) if state.plans else 0.1
+        proposed = {'action': 'adjust_contamination',
+                    'value': max(current * 0.5, 0.01)}
+        confidence = 0.7
+
+    elif ('missed' in lower or 'false negative' in lower):
+        current = state.plans[0].get('params', {}).get(
+            'contamination', 0.1) if state.plans else 0.1
+        proposed = {'action': 'adjust_contamination',
+                    'value': min(current * 1.5, 0.5)}
+        confidence = 0.7
+
+    elif 'rerun' in lower or 'again' in lower:
+        proposed = {'action': 'rerun'}
+        confidence = 0.9
+
+    if proposed is None:
+        proposed = {'action': 'rerun'}
+        confidence = 0.0
+
+    if confidence >= 0.8:
+        return apply_structured_feedback(
+            state, proposed, kb, plan_detection_fn, make_plan_fn)
+
+    # Low confidence → ask for confirmation
+    state.next_action = {
+        'action': 'confirm_with_user',
+        'reason': 'Interpreted "%s" as: %s (confidence=%.1f).'
+                  % (feedback, proposed.get('action', '?'),
+                     confidence),
+        'suggestion': 'Proposed: %s. Proceed?' % str(proposed),
+        'proposed_change': proposed,
+    }
+    state.history.append(_make_history_entry(
+        state.phase, 'iterate_nl', state.iteration,
+        'NL feedback: "%s" -> confidence=%.1f'
+        % (feedback, confidence)))
+    return state

--- a/pyod/utils/_quality_metrics.py
+++ b/pyod/utils/_quality_metrics.py
@@ -1,0 +1,349 @@
+"""Quality metrics for ADEngine result analysis.
+
+Pure helper functions extracted from `pyod.utils.ad_engine.ADEngine` in
+2026-05 (issue #667 follow-up). Not part of the public API; the
+leading underscore on the module name is the contract.
+"""
+
+import numpy as np
+from scipy.stats import rankdata, spearmanr
+
+
+def compute_quality(scores, labels, results, consensus):
+    """Compute three diagnostic quality metrics for a detection run.
+
+    Each metric diagnoses one independent failure mode and drives
+    one branch of `ADEngine.iterate()`:
+
+    - ``separation``: anomaly-vs-inlier mean score gap (global).
+      Low value indicates the detector did not produce a usable signal.
+    - ``agreement``: pairwise Spearman rank correlation across base
+      detectors (cross-detector). Low value indicates detectors
+      disagree on which samples are anomalous.
+    - ``stability``: standardized score gap at the rank-k cutoff
+      (local). Computed as
+      ``(score[rank_k] - score[rank_k+1]) / scores.std()``, clipped
+      to ``[0, 1]``. Low value indicates many tied scores near the
+      threshold; the anomaly set is sensitive to the contamination
+      value, and ``adjust_contamination`` is the suggested action.
+
+    The ``stability`` key was historically defined (and
+    mis-implemented) as the Jaccard index of nested top-k slices,
+    which collapses to a constant. The formula was revised in pyod
+    v3.3 (closes #667). The key name is retained for backwards
+    compatibility with v3.2.x callers.
+
+    Parameters
+    ----------
+    scores : np.ndarray, shape (n_samples,)
+        Consensus or per-detector anomaly scores. Higher means more
+        anomalous.
+    labels : np.ndarray, shape (n_samples,)
+        Binary labels (0 inlier, 1 anomaly).
+    results : list of dict
+        Per-detector results from `ADEngine.run()`. Reserved for
+        callers that thread per-detector data through quality
+        computation. Not directly read by this method.
+    consensus : dict
+        Consensus dict from `ADEngine.run()`. Provides the
+        ``agreement`` field.
+
+    Returns
+    -------
+    dict
+        Keys: ``separation`` (float in [0, 1]), ``agreement`` (float
+        in [0, 1]), ``stability`` (float in [0, 1]), ``overall``
+        (float in [0, 1], mean of the three), ``verdict`` (one of
+        ``'high'``, ``'medium'``, ``'low'``), ``explanation``
+        (human-readable summary).
+    """
+    n_anomalies = int(labels.sum())
+    n_samples = len(labels)
+    # Non-finite scores poison both separation (mean) and stability
+    # (sort + std). Short-circuit both to refuse to emit NaN.
+    nonfinite_scores = not np.all(np.isfinite(scores))
+
+    # Separation
+    if (nonfinite_scores or n_anomalies == 0
+            or n_anomalies == n_samples):
+        separation = 0.0
+    else:
+        anomaly_mean = float(np.mean(scores[labels == 1]))
+        inlier_mean = float(np.mean(scores[labels == 0]))
+        separation = float(np.clip(
+            anomaly_mean / (inlier_mean + 1e-10) - 1, 0, 1))
+
+    # Agreement (from consensus)
+    agreement = float(consensus.get('agreement', 0.5))
+
+    # Stability: standardized score gap at the rank-k cutoff.
+    # Replaces the v1 Jaccard-of-nested-top-k formula which was
+    # mathematically constant (issue #667).
+    if (n_anomalies == 0 or n_anomalies >= n_samples
+            or nonfinite_scores):
+        stability = 0.0
+    else:
+        sorted_scores = np.sort(scores)[::-1]
+        gap = float(sorted_scores[n_anomalies - 1]
+                    - sorted_scores[n_anomalies])
+        std = float(scores.std())
+        if std == 0.0:
+            stability = 0.0
+        else:
+            stability = float(np.clip(gap / std, 0.0, 1.0))
+
+    overall = float(np.mean([separation, agreement, stability]))
+    if overall >= 0.7:
+        verdict = 'high'
+    elif overall >= 0.4:
+        verdict = 'medium'
+    else:
+        verdict = 'low'
+
+    return {
+        'separation': separation,
+        'agreement': agreement,
+        'stability': stability,
+        'overall': overall,
+        'verdict': verdict,
+        'explanation': 'separation={:.2f}, agreement={:.2f}, '
+                       'stability={:.2f} (cutoff gap)'.format(
+                           separation, agreement, stability),
+    }
+
+
+def select_best_detector(results, consensus_scores):
+    """Select best detector via Spearman with consensus.
+
+    Fallback chain (per spec):
+
+    1. Highest finite Spearman correlation against consensus.
+    2. If tied: highest plan confidence.
+    3. If still tied: fastest runtime.
+    4. If ALL correlations are non-finite: first successful detector.
+
+    Parameters
+    ----------
+    results : list of dict
+        Per-detector result dicts from `ADEngine.run()`. Each dict has
+        keys ``'status'``, ``'scores_train'``, ``'detector_name'``,
+        ``'plan'`` (with ``'confidence'``), and ``'runtime_seconds'``.
+        Only entries with ``status == 'success'`` are considered.
+    consensus_scores : np.ndarray, shape (n_samples,)
+        Consensus anomaly scores from `compute_consensus`.
+
+    Returns
+    -------
+    int
+        Index into `results` of the best-aligned successful detector.
+        When only one detector succeeds, returns its index. When all
+        Spearman correlations are non-finite, returns the index of the
+        first successful detector.
+    """
+    successful = [
+        (i, r) for i, r in enumerate(results)
+        if r['status'] == 'success']
+    if len(successful) == 1:
+        return successful[0][0]
+
+    # Compute Spearman for each successful detector
+    rhos = []
+    for i, r in successful:
+        rho, _ = spearmanr(r['scores_train'], consensus_scores)
+        rhos.append(float(rho) if np.isfinite(rho) else None)
+
+    # If ALL NaN: return first successful (spec rule 4)
+    if all(rho is None for rho in rhos):
+        return successful[0][0]
+
+    # Find best by finite Spearman, then tie-break
+    best_j = 0  # index into successful list
+    best_rho = -1.0
+    for j, (i, r) in enumerate(successful):
+        rho = rhos[j]
+        if rho is None:
+            continue
+        if rho > best_rho:
+            best_rho = rho
+            best_j = j
+        elif rho == best_rho:
+            # Tie-break: plan confidence
+            curr_conf = r.get('plan', {}).get('confidence', 0)
+            prev_conf = successful[best_j][1].get(
+                'plan', {}).get('confidence', 0)
+            if curr_conf > prev_conf:
+                best_j = j
+            elif curr_conf == prev_conf:
+                # Tie-break: fastest
+                if r.get('runtime_seconds', 999) < successful[
+                        best_j][1].get('runtime_seconds', 999):
+                    best_j = j
+    return successful[best_j][0]
+
+
+def compute_feature_importance(result, X):
+    """Estimate per-feature contribution to anomaly scores.
+
+    For each feature column, computes the Pearson correlation between
+    the column's absolute z-scores and the detector's anomaly scores.
+    Higher absolute correlation indicates the feature drives the
+    detector's ranking. Failures (non-2D `X`, length mismatch, or any
+    exception during computation) return ``None`` rather than raise.
+
+    Parameters
+    ----------
+    result : dict
+        Detector result dict. Must contain ``'scores_train'`` (an
+        ndarray of length ``n_samples``).
+    X : array-like, shape (n_samples, n_features)
+        Training data the detector was fit on.
+
+    Returns
+    -------
+    list of float or None
+        One importance per feature, in column order. Each value is in
+        [-1, 1]; non-finite correlations are coerced to 0.0. Returns
+        ``None`` if `X` is not 2D, if length of scores does not match
+        `X.shape[0]`, or if any error occurs during computation.
+    """
+    try:
+        X_arr = np.asarray(X, dtype=np.float64)
+        if X_arr.ndim != 2:
+            return None
+        scores = result['scores_train']
+        if len(scores) != X_arr.shape[0]:
+            return None
+
+        means = np.mean(X_arr, axis=0)
+        stds = np.std(X_arr, axis=0)
+        stds[stds == 0] = 1.0
+        z_scores = np.abs((X_arr - means) / stds)
+
+        importances = []
+        for j in range(X_arr.shape[1]):
+            corr = np.corrcoef(z_scores[:, j], scores)[0, 1]
+            importances.append(float(corr) if np.isfinite(corr) else 0.0)
+
+        return importances
+    except Exception:
+        return None
+
+
+def feature_contributions(X, idx, scores):
+    """Compute per-feature z-score for a specific sample.
+
+    Returns the top-5 features by absolute z-score for the row at
+    `idx`. Used to explain why a single sample looks anomalous. The
+    `scores` argument is part of the call signature for API symmetry
+    with `compute_feature_importance` but is not currently read.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_samples, n_features)
+        Training data.
+    idx : int
+        Row index of the sample to explain.
+    scores : np.ndarray, shape (n_samples,)
+        Anomaly scores (currently unused; reserved for future weighting).
+
+    Returns
+    -------
+    list of dict or None
+        Up to five entries, each with keys ``'feature'`` (int column
+        index) and ``'z_score'`` (float, absolute z-score), sorted by
+        descending z-score. Returns ``None`` if `X` is not 2D or any
+        error occurs during computation.
+    """
+    try:
+        X_arr = np.asarray(X, dtype=np.float64)
+        if X_arr.ndim != 2:
+            return None
+        means = np.mean(X_arr, axis=0)
+        stds = np.std(X_arr, axis=0)
+        stds[stds == 0] = 1.0
+        z = np.abs((X_arr[idx] - means) / stds)
+        top_feat = np.argsort(z)[::-1][:5]
+        return [{'feature': int(f), 'z_score': float(z[f])}
+                for f in top_feat]
+    except Exception:
+        return None
+
+
+def compute_consensus(successful_results):
+    """Compute consensus from successful detector results.
+
+    Rank-normalizes scores per detector via ``rankdata``, averages to
+    get consensus scores, takes a majority vote on labels, computes
+    pairwise Spearman correlation for the agreement metric, and
+    flags indices where detectors disagree.
+
+    Parameters
+    ----------
+    successful_results : list of dict
+        Successful detector result dicts. Each must contain
+        ``'scores_train'`` and ``'labels_train'`` ndarrays.
+
+    Returns
+    -------
+    dict or None
+        Returns ``None`` when ``successful_results`` is empty. With
+        exactly one successful result, returns a single-detector
+        consensus with ``agreement=0.5``. Otherwise returns a dict
+        with keys ``'scores'``, ``'labels'``, ``'n_detectors'``,
+        ``'agreement'``, and ``'disagreements'``.
+    """
+    successful = successful_results
+
+    if len(successful) == 0:
+        return None
+
+    if len(successful) == 1:
+        r = successful[0]
+        return {
+            'scores': r['scores_train'],
+            'labels': r['labels_train'],
+            'n_detectors': 1,
+            'agreement': 0.5,
+            'disagreements': [],
+        }
+
+    n_samples = len(successful[0]['scores_train'])
+    # Rank-normalize scores per detector
+    rank_scores = np.array([
+        rankdata(r['scores_train']) / n_samples
+        for r in successful
+    ])
+    consensus_scores = np.mean(rank_scores, axis=0)
+
+    # Majority-vote labels
+    all_labels = np.array([
+        r['labels_train'] for r in successful])
+    vote_count = np.sum(all_labels, axis=0)
+    consensus_labels = (
+        vote_count > len(successful) / 2).astype(int)
+
+    # Pairwise Spearman agreement
+    correlations = []
+    for i in range(len(successful)):
+        for j in range(i + 1, len(successful)):
+            rho, _ = spearmanr(
+                successful[i]['scores_train'],
+                successful[j]['scores_train'])
+            correlations.append(
+                max(0.0, rho) if np.isfinite(rho) else 0.0)
+    agreement = float(np.mean(correlations)) if correlations else 0.5
+
+    # Disagreements: indices where detectors disagree
+    disagreements = []
+    for idx in range(n_samples):
+        votes = all_labels[:, idx]
+        if not (votes.all() or not votes.any()):
+            disagreements.append(int(idx))
+
+    return {
+        'scores': consensus_scores,
+        'labels': consensus_labels,
+        'n_detectors': len(successful),
+        'agreement': agreement,
+        'disagreements': disagreements,
+    }

--- a/pyod/utils/ad_engine.py
+++ b/pyod/utils/ad_engine.py
@@ -8,12 +8,30 @@ required) or as the backend for MCP/agent interfaces.
 # Author: Yue Zhao <yzhao062@gmail.com>
 # License: BSD 2 clause
 
-import importlib
 import os
 
 import numpy as np
 
 from .knowledge import KnowledgeBase
+from pyod.utils._quality_metrics import (
+    compute_consensus,
+    compute_feature_importance,
+    compute_quality,
+    feature_contributions,
+    select_best_detector,
+)
+from pyod.utils._kb_router import (
+    evaluate_rules,
+    make_plan,
+    suggest_alternative,
+)
+from pyod.utils._detector_factory import (
+    build_detector_from_plan,
+)
+from pyod.utils._nl_feedback import (
+    apply_nl_feedback,
+    apply_structured_feedback,
+)
 
 
 class ADEngine:
@@ -142,7 +160,7 @@ class ADEngine:
         constraints = constraints or {}
         exclude = set(constraints.get('exclude_detectors', []))
 
-        matched = self._evaluate_rules(profile, priority)
+        matched = evaluate_rules(profile, priority, self.kb)
 
         valid = []
         for rec in matched:
@@ -168,7 +186,7 @@ class ADEngine:
                         fallback_name = fb
                         break
             if fallback_name is None:
-                return self._make_plan(
+                return make_plan(
                     detector_name='',
                     params={},
                     reason='No valid detector available: all candidates '
@@ -178,7 +196,7 @@ class ADEngine:
                     alternatives=[],
                     note='no_valid_plan')
 
-            return self._make_plan(
+            return make_plan(
                 detector_name=fallback_name, params={},
                 reason='Fallback: no routing rule matched or all '
                        'candidates excluded',
@@ -186,7 +204,7 @@ class ADEngine:
                 alternatives=[], note='No specific rule matched')
 
         best = valid[0]
-        alternatives = [self._make_plan(
+        alternatives = [make_plan(
             detector_name=r['detector'],
             params=r.get('params', {}),
             preset=r.get('preset'),
@@ -195,7 +213,7 @@ class ADEngine:
             confidence=r.get('confidence', 0.5),
             alternatives=[]) for r in valid[1:3]]
 
-        return self._make_plan(
+        return make_plan(
             detector_name=best['detector'],
             params=best.get('params', {}),
             preset=best.get('preset'),
@@ -203,86 +221,6 @@ class ADEngine:
             evidence=best.get('_evidence', []),
             confidence=best.get('confidence', 0.7),
             alternatives=alternatives)
-
-    def _evaluate_rules(self, profile, priority):
-        """Evaluate routing rules against profile. Returns matched
-        recommendations with their rule context."""
-        rules = self.kb.routing_rules.get('rules', [])
-        all_recs = []
-
-        for rule in rules:
-            if self._rule_matches(rule, profile, priority):
-                reason = rule.get('reason', '')
-                evidence = rule.get('evidence', [])
-                for rec in rule.get('recommendations', []):
-                    enriched = dict(rec)
-                    enriched['_reason'] = reason
-                    enriched['_evidence'] = evidence
-                    all_recs.append(enriched)
-
-        seen = {}
-        for rec in all_recs:
-            name = rec['detector']
-            if name not in seen or \
-                    rec.get('confidence', 0) > seen[name].get('confidence', 0):
-                seen[name] = rec
-        return sorted(seen.values(),
-                      key=lambda r: r.get('confidence', 0),
-                      reverse=True)
-
-    def _rule_matches(self, rule, profile, priority):
-        """Check if all conditions in a rule match the profile."""
-        for cond in rule.get('conditions', []):
-            field = cond['field']
-            op = cond['op']
-            value = cond['value']
-
-            if field == 'priority':
-                actual = priority
-            else:
-                actual = profile.get(field)
-
-            if actual is None:
-                return False
-            if not self._eval_condition(actual, op, value):
-                return False
-        return True
-
-    @staticmethod
-    def _eval_condition(actual, op, value):
-        """Evaluate a single condition predicate."""
-        if op == 'eq':
-            return actual == value
-        if op == 'lt':
-            return float(actual) < float(value)
-        if op == 'lte':
-            return float(actual) <= float(value)
-        if op == 'gt':
-            return float(actual) > float(value)
-        if op == 'gte':
-            return float(actual) >= float(value)
-        if op == 'in':
-            return actual in value
-        return False
-
-    @staticmethod
-    def _make_plan(detector_name, params=None, preset=None,
-                   reason='', evidence=None, confidence=0.5,
-                   alternatives=None, note=None):
-        """Construct a closed-schema DetectionPlan dict."""
-        plan = {
-            'detector_name': detector_name,
-            'params': params or {},
-            'reason': reason,
-            'evidence': evidence or [],
-            'confidence': confidence,
-            'alternatives': alternatives or [],
-        }
-        if preset:
-            plan['preset'] = preset
-        if note:
-            plan['note'] = note
-        return plan
 
     # ------------------------------------------------------------------
     # Detector construction
@@ -300,38 +238,7 @@ class ADEngine:
         -------
         detector : BaseDetector
         """
-        name = plan['detector_name']
-        algo = self.kb.get_algorithm(name)
-        if algo is None:
-            raise ValueError("Unknown detector '%s'" % name)
-        if algo.get('status') not in ('shipped', 'experimental'):
-            raise ValueError(
-                "Detector '%s' has status '%s' and cannot be built"
-                % (name, algo.get('status', 'unknown')))
-
-        preset = plan.get('preset')
-        if preset:
-            return self._build_from_preset(name, preset,
-                                           plan.get('params', {}))
-
-        class_path = algo['class_path']
-        module_path, class_name = class_path.rsplit('.', 1)
-        mod = importlib.import_module(module_path)
-        cls = getattr(mod, class_name)
-        params = plan.get('params', {})
-        return cls(**params)
-
-    @staticmethod
-    def _build_from_preset(detector_name, preset, extra_params):
-        """Build a detector using a factory preset."""
-        if detector_name == 'EmbeddingOD':
-            from pyod.models.embedding import EmbeddingOD
-            if preset == 'for_text':
-                return EmbeddingOD.for_text(**extra_params)
-            elif preset == 'for_image':
-                return EmbeddingOD.for_image(**extra_params)
-        raise ValueError("Unknown preset '%s' for '%s'"
-                         % (preset, detector_name))
+        return build_detector_from_plan(plan, self.kb)
 
     # ------------------------------------------------------------------
     # One-shot detection
@@ -489,36 +396,11 @@ class ADEngine:
         }
 
         if X is not None:
-            fi = self._compute_feature_importance(result, X)
+            fi = compute_feature_importance(result, X)
             if fi is not None:
                 analysis['feature_importance'] = fi
 
         return analysis
-
-    @staticmethod
-    def _compute_feature_importance(result, X):
-        """Estimate per-feature contribution to anomaly scores."""
-        try:
-            X_arr = np.asarray(X, dtype=np.float64)
-            if X_arr.ndim != 2:
-                return None
-            scores = result['scores_train']
-            if len(scores) != X_arr.shape[0]:
-                return None
-
-            means = np.mean(X_arr, axis=0)
-            stds = np.std(X_arr, axis=0)
-            stds[stds == 0] = 1.0
-            z_scores = np.abs((X_arr - means) / stds)
-
-            importances = []
-            for j in range(X_arr.shape[1]):
-                corr = np.corrcoef(z_scores[:, j], scores)[0, 1]
-                importances.append(float(corr) if np.isfinite(corr) else 0.0)
-
-            return importances
-        except Exception:
-            return None
 
     # ------------------------------------------------------------------
     # Explanation
@@ -580,30 +462,13 @@ class ADEngine:
             }
 
             if X is not None:
-                contribs = self._feature_contributions(X, idx, scores)
+                contribs = feature_contributions(X, idx, scores)
                 if contribs is not None:
                     entry['contributing_features'] = contribs
 
             explanations.append(entry)
 
         return explanations
-
-    @staticmethod
-    def _feature_contributions(X, idx, scores):
-        """Compute per-feature z-score for a specific sample."""
-        try:
-            X_arr = np.asarray(X, dtype=np.float64)
-            if X_arr.ndim != 2:
-                return None
-            means = np.mean(X_arr, axis=0)
-            stds = np.std(X_arr, axis=0)
-            stds[stds == 0] = 1.0
-            z = np.abs((X_arr[idx] - means) / stds)
-            top_feat = np.argsort(z)[::-1][:5]
-            return [{'feature': int(f), 'z_score': float(z[f])}
-                    for f in top_feat]
-        except Exception:
-            return None
 
     # ------------------------------------------------------------------
     # Next-step suggestions
@@ -636,7 +501,7 @@ class ADEngine:
                 'action': 'try_alternative',
                 'reason': 'Consider running multiple detectors and '
                           'combining scores.',
-                'new_plan': self._suggest_alternative(result),
+                'new_plan': suggest_alternative(result, self.kb, make_plan),
             }
 
         # "more sensitive" intent: lower threshold / increase contamination
@@ -692,7 +557,7 @@ class ADEngine:
 
         if ('different' in feedback_lower or 'another' in feedback_lower
                 or 'switch' in feedback_lower):
-            new_plan = self._suggest_alternative(result)
+            new_plan = suggest_alternative(result, self.kb, make_plan)
             return {
                 'action': 'try_alternative',
                 'reason': 'Trying an alternative detector.',
@@ -716,7 +581,7 @@ class ADEngine:
                 },
             }
         if ratio == 0:
-            new_plan = self._suggest_alternative(result)
+            new_plan = suggest_alternative(result, self.kb, make_plan)
             return {
                 'action': 'try_alternative',
                 'reason': 'No anomalies detected. Try a different detector.',
@@ -729,30 +594,6 @@ class ADEngine:
                       'Review the top anomalies to validate.'
                       % (ratio * 100),
         }
-
-    def _suggest_alternative(self, result):
-        """Suggest an alternative detector different from the current one."""
-        current = result['plan'].get('detector_name', '')
-
-        alternatives = result['plan'].get('alternatives', [])
-        for alt in alternatives:
-            if alt.get('detector_name') and alt['detector_name'] != current:
-                return alt
-
-        fallback_order = ['IForest', 'ECOD', 'KNN', 'LOF', 'HBOS',
-                          'COPOD', 'CBLOF']
-        for name in fallback_order:
-            if name != current:
-                algo = self.kb.get_algorithm(name)
-                if algo and algo.get('status') == 'shipped':
-                    return self._make_plan(
-                        detector_name=name, params={},
-                        reason='Alternative to %s' % current,
-                        evidence=[], confidence=0.6)
-
-        return self._make_plan(
-            detector_name='IForest', params={},
-            reason='Default fallback', evidence=[], confidence=0.5)
 
     # ------------------------------------------------------------------
     # Report generation
@@ -945,7 +786,6 @@ class ADEngine:
         """
         self._require_phase(state, 'planned')
         from .investigation import _make_history_entry
-        from scipy.stats import rankdata, spearmanr
 
         results = []
         for plan in state.plans:
@@ -969,74 +809,26 @@ class ADEngine:
 
         # Compute consensus from successful detectors
         successful = [r for r in results if r['status'] == 'success']
+        state.consensus = compute_consensus(successful)
 
-        if len(successful) == 0:
-            state.consensus = None
+        if state.consensus is None:
             state.next_action = {
                 'action': 'confirm_with_user',
                 'reason': 'All %d detectors failed. Check data format '
                           'or try a different detector family.'
                           % len(results),
             }
-        elif len(successful) == 1:
-            r = successful[0]
-            state.consensus = {
-                'scores': r['scores_train'],
-                'labels': r['labels_train'],
-                'n_detectors': 1,
-                'agreement': 0.5,
-                'disagreements': [],
-            }
+        elif state.consensus['n_detectors'] == 1:
             state.next_action = {
                 'action': 'analyze',
                 'reason': 'Detection complete (1 detector).',
             }
         else:
-            n_samples = len(successful[0]['scores_train'])
-            # Rank-normalize scores per detector
-            rank_scores = np.array([
-                rankdata(r['scores_train']) / n_samples
-                for r in successful
-            ])
-            consensus_scores = np.mean(rank_scores, axis=0)
-
-            # Majority-vote labels
-            all_labels = np.array([
-                r['labels_train'] for r in successful])
-            vote_count = np.sum(all_labels, axis=0)
-            consensus_labels = (
-                vote_count > len(successful) / 2).astype(int)
-
-            # Pairwise Spearman agreement
-            correlations = []
-            for i in range(len(successful)):
-                for j in range(i + 1, len(successful)):
-                    rho, _ = spearmanr(
-                        successful[i]['scores_train'],
-                        successful[j]['scores_train'])
-                    correlations.append(
-                        max(0.0, rho) if np.isfinite(rho) else 0.0)
-            agreement = float(np.mean(correlations)) if correlations else 0.5
-
-            # Disagreements: indices where detectors disagree
-            disagreements = []
-            for idx in range(n_samples):
-                votes = all_labels[:, idx]
-                if not (votes.all() or not votes.any()):
-                    disagreements.append(int(idx))
-
-            state.consensus = {
-                'scores': consensus_scores,
-                'labels': consensus_labels,
-                'n_detectors': len(successful),
-                'agreement': agreement,
-                'disagreements': disagreements,
-            }
             state.next_action = {
                 'action': 'analyze',
                 'reason': 'Detection complete (%d detectors, '
-                          'agreement=%.2f).'
-                          % (len(successful), agreement),
+                          'agreement=%.2f).' % (state.consensus['n_detectors'],
+                                                state.consensus['agreement']),
             }
 
         state.history.append(_make_history_entry(
@@ -1062,7 +854,6 @@ class ADEngine:
         """
         self._require_phase(state, 'detected')
         from .investigation import _make_history_entry
-        from scipy.stats import spearmanr
 
         state.phase = 'analyzed'
 
@@ -1130,7 +921,7 @@ class ADEngine:
         }
 
         # Best detector selection
-        best_idx = self._select_best_detector(
+        best_idx = select_best_detector(
             state.results, c_scores)
 
         state.analysis = {
@@ -1142,7 +933,7 @@ class ADEngine:
         }
 
         # Quality metrics
-        state.quality = self._compute_quality(
+        state.quality = compute_quality(
             c_scores, c_labels, state.results, c)
         state.analysis['summary'] += (
             ' Quality: %s (%.2f).'
@@ -1175,159 +966,6 @@ class ADEngine:
                 state.quality['overall'])))
         return state
 
-    def _select_best_detector(self, results, consensus_scores):
-        """Select best detector via Spearman with consensus.
-
-        Fallback chain (per spec):
-        1. Highest finite Spearman correlation
-        2. If tied: highest plan confidence
-        3. If still tied: fastest runtime
-        4. If ALL correlations are NaN: first successful detector
-        """
-        from scipy.stats import spearmanr
-
-        successful = [
-            (i, r) for i, r in enumerate(results)
-            if r['status'] == 'success']
-        if len(successful) == 1:
-            return successful[0][0]
-
-        # Compute Spearman for each successful detector
-        rhos = []
-        for i, r in successful:
-            rho, _ = spearmanr(r['scores_train'], consensus_scores)
-            rhos.append(float(rho) if np.isfinite(rho) else None)
-
-        # If ALL NaN: return first successful (spec rule 4)
-        if all(rho is None for rho in rhos):
-            return successful[0][0]
-
-        # Find best by finite Spearman, then tie-break
-        best_j = 0  # index into successful list
-        best_rho = -1.0
-        for j, (i, r) in enumerate(successful):
-            rho = rhos[j]
-            if rho is None:
-                continue
-            if rho > best_rho:
-                best_rho = rho
-                best_j = j
-            elif rho == best_rho:
-                # Tie-break: plan confidence
-                curr_conf = r.get('plan', {}).get('confidence', 0)
-                prev_conf = successful[best_j][1].get(
-                    'plan', {}).get('confidence', 0)
-                if curr_conf > prev_conf:
-                    best_j = j
-                elif curr_conf == prev_conf:
-                    # Tie-break: fastest
-                    if r.get('runtime_seconds', 999) < successful[
-                            best_j][1].get('runtime_seconds', 999):
-                        best_j = j
-        return successful[best_j][0]
-
-    def _compute_quality(self, scores, labels, results, consensus):
-        """Compute three diagnostic quality metrics for a detection run.
-
-        Each metric diagnoses one independent failure mode and drives
-        one branch of `ADEngine.iterate()`:
-
-        - ``separation``: anomaly-vs-inlier mean score gap (global).
-          Low value indicates the detector did not produce a usable signal.
-        - ``agreement``: pairwise Spearman rank correlation across base
-          detectors (cross-detector). Low value indicates detectors
-          disagree on which samples are anomalous.
-        - ``stability``: standardized score gap at the rank-k cutoff
-          (local). Computed as
-          ``(score[rank_k] - score[rank_k+1]) / scores.std()``, clipped
-          to ``[0, 1]``. Low value indicates many tied scores near the
-          threshold; the anomaly set is sensitive to the contamination
-          value, and ``adjust_contamination`` is the suggested action.
-
-        The ``stability`` key was historically defined (and
-        mis-implemented) as the Jaccard index of nested top-k slices,
-        which collapses to a constant. The formula was revised in pyod
-        v3.3 (closes #667). The key name is retained for backwards
-        compatibility with v3.2.x callers.
-
-        Parameters
-        ----------
-        scores : np.ndarray, shape (n_samples,)
-            Consensus or per-detector anomaly scores. Higher means more
-            anomalous.
-        labels : np.ndarray, shape (n_samples,)
-            Binary labels (0 inlier, 1 anomaly).
-        results : list of dict
-            Per-detector results from `ADEngine.run()`. Reserved for
-            callers that thread per-detector data through quality
-            computation. Not directly read by this method.
-        consensus : dict
-            Consensus dict from `ADEngine.run()`. Provides the
-            ``agreement`` field.
-
-        Returns
-        -------
-        dict
-            Keys: ``separation`` (float in [0, 1]), ``agreement`` (float
-            in [0, 1]), ``stability`` (float in [0, 1]), ``overall``
-            (float in [0, 1], mean of the three), ``verdict`` (one of
-            ``'high'``, ``'medium'``, ``'low'``), ``explanation``
-            (human-readable summary).
-        """
-        n_anomalies = int(labels.sum())
-        n_samples = len(labels)
-        # Non-finite scores poison both separation (mean) and stability
-        # (sort + std). Short-circuit both to refuse to emit NaN.
-        nonfinite_scores = not np.all(np.isfinite(scores))
-
-        # Separation
-        if (nonfinite_scores or n_anomalies == 0
-                or n_anomalies == n_samples):
-            separation = 0.0
-        else:
-            anomaly_mean = float(np.mean(scores[labels == 1]))
-            inlier_mean = float(np.mean(scores[labels == 0]))
-            separation = float(np.clip(
-                anomaly_mean / (inlier_mean + 1e-10) - 1, 0, 1))
-
-        # Agreement (from consensus)
-        agreement = float(consensus.get('agreement', 0.5))
-
-        # Stability: standardized score gap at the rank-k cutoff.
-        # Replaces the v1 Jaccard-of-nested-top-k formula which was
-        # mathematically constant (issue #667).
-        if (n_anomalies == 0 or n_anomalies >= n_samples
-                or nonfinite_scores):
-            stability = 0.0
-        else:
-            sorted_scores = np.sort(scores)[::-1]
-            gap = float(sorted_scores[n_anomalies - 1]
-                        - sorted_scores[n_anomalies])
-            std = float(scores.std())
-            if std == 0.0:
-                stability = 0.0
-            else:
-                stability = float(np.clip(gap / std, 0.0, 1.0))
-
-        overall = float(np.mean([separation, agreement, stability]))
-        if overall >= 0.7:
-            verdict = 'high'
-        elif overall >= 0.4:
-            verdict = 'medium'
-        else:
-            verdict = 'low'
-
-        return {
-            'separation': separation,
-            'agreement': agreement,
-            'stability': stability,
-            'overall': overall,
-            'verdict': verdict,
-            'explanation': 'separation={:.2f}, agreement={:.2f}, '
-                           'stability={:.2f} (cutoff gap)'.format(
-                               separation, agreement, stability),
-        }
-
     # ------------------------------------------------------------------
     # V3 Session workflow: iterate
     # ------------------------------------------------------------------
@@ -1350,154 +988,10 @@ class ADEngine:
         """
         self._require_phase(state, 'analyzed')
         if isinstance(feedback, dict):
-            return self._iterate_structured(state, feedback)
-        return self._iterate_nl(state, str(feedback))
-
-    def _iterate_structured(self, state, feedback):
-        """Handle structured feedback dict."""
-        from .investigation import _make_history_entry
-
-        action = feedback.get('action', '')
-        state.iteration += 1
-
-        if action == 'adjust_contamination':
-            value = feedback['value']
-            for p in state.plans:
-                params = dict(p.get('params', {}))
-                params['contamination'] = value
-                p['params'] = params
-            detail = 'Adjusted contamination to %.3f' % value
-
-        elif action == 'exclude':
-            to_exclude = set(feedback.get('detectors', []))
-            state.plans = [
-                p for p in state.plans
-                if p['detector_name'] not in to_exclude]
-            if not state.plans:
-                # Re-plan without excluded detectors
-                result = self.plan_detection(
-                    state.profile,
-                    constraints={'exclude_detectors': list(to_exclude)})
-                state.plans = [result]
-                for alt in result.get('alternatives', []):
-                    if alt.get('detector_name'):
-                        state.plans.append(alt)
-            detail = 'Excluded: %s' % ', '.join(to_exclude)
-
-        elif action == 'include':
-            to_include = feedback.get('detectors', [])
-            existing = {p['detector_name'] for p in state.plans}
-            added, already, capped = [], [], []
-            for name in to_include:
-                if name in existing:
-                    already.append(name)
-                elif len(state.plans) >= 3:
-                    capped.append(name)
-                else:
-                    algo = self.kb.get_algorithm(name)
-                    if algo and algo.get('status') in (
-                            'shipped', 'experimental'):
-                        state.plans.append(self._make_plan(
-                            detector_name=name, params={},
-                            reason='Added by user', confidence=0.5))
-                        added.append(name)
-            parts = []
-            if added:
-                parts.append('Included: %s' % ', '.join(added))
-            if already:
-                parts.append('Already present: %s'
-                             % ', '.join(already))
-            if capped:
-                parts.append('Could not add %s (v1 cap: 3)'
-                             % ', '.join(capped))
-            detail = '. '.join(parts) if parts else 'No changes'
-
-        elif action == 'rerun':
-            detail = 'Re-running same plan'
-
-        else:
-            state.next_action = {
-                'action': 'confirm_with_user',
-                'reason': 'Unknown action: %s' % action,
-            }
-            return state
-
-        state.phase = 'planned'
-        state.results = []
-        state.consensus = None
-        state.analysis = None
-        state.quality = None
-        state.next_action = {
-            'action': 'run',
-            'reason': 'Plan adjusted. ' + detail,
-            'adjustment': detail,
-        }
-        state.history.append(_make_history_entry(
-            'planned', 'iterate', state.iteration, detail))
-        return state
-
-    def _iterate_nl(self, state, feedback):
-        """Parse NL feedback into structured action."""
-        from .investigation import _make_history_entry
-
-        lower = feedback.lower()
-        proposed = None
-        confidence = 0.0
-
-        # High-confidence patterns
-        if 'without' in lower or 'exclude' in lower:
-            # Try to extract detector name
-            for r in state.results:
-                name = r.get('detector_name', '')
-                if name.lower() in lower:
-                    proposed = {'action': 'exclude',
-                                'detectors': [name]}
-                    confidence = 0.9
-                    break
-            if proposed is None and ('without' in lower
-                                     or 'exclude' in lower):
-                proposed = {'action': 'exclude', 'detectors': []}
-                confidence = 0.3
-
-        elif ('false positive' in lower or 'too many' in lower):
-            current = state.plans[0].get('params', {}).get(
-                'contamination', 0.1) if state.plans else 0.1
-            proposed = {'action': 'adjust_contamination',
-                        'value': max(current * 0.5, 0.01)}
-            confidence = 0.7
-
-        elif ('missed' in lower or 'false negative' in lower):
-            current = state.plans[0].get('params', {}).get(
-                'contamination', 0.1) if state.plans else 0.1
-            proposed = {'action': 'adjust_contamination',
-                        'value': min(current * 1.5, 0.5)}
-            confidence = 0.7
-
-        elif 'rerun' in lower or 'again' in lower:
-            proposed = {'action': 'rerun'}
-            confidence = 0.9
-
-        if proposed is None:
-            proposed = {'action': 'rerun'}
-            confidence = 0.0
-
-        if confidence >= 0.8:
-            return self._iterate_structured(state, proposed)
-
-        # Low confidence → ask for confirmation
-        state.next_action = {
-            'action': 'confirm_with_user',
-            'reason': 'Interpreted "%s" as: %s (confidence=%.1f).'
-                      % (feedback, proposed.get('action', '?'),
-                         confidence),
-            'suggestion': 'Proposed: %s. Proceed?' % str(proposed),
-            'proposed_change': proposed,
-        }
-        state.history.append(_make_history_entry(
-            state.phase, 'iterate_nl', state.iteration,
-            'NL feedback: "%s" -> confidence=%.1f'
-            % (feedback, confidence)))
-        return state
+            return apply_structured_feedback(
+                state, feedback, self.kb, self.plan_detection, make_plan)
+        return apply_nl_feedback(
+            state, str(feedback), self.kb, self.plan_detection, make_plan)
 
     # ------------------------------------------------------------------
     # V3 Session workflow: report and investigate


### PR DESCRIPTION
## Summary

Pure structural refactor of `pyod/utils/ad_engine.py`. 12 private methods + 1 inline consensus block move into 4 new private helper modules. The public `ADEngine` class and its 20 public methods are preserved exactly.

This is **PR 2 of 3** in the ADEngine refactor sequence. PR 1 (#668) shipped the stability bug fix. PR 3 will add type hints, magic-number constants, validation, and exception-handling tightening.

## Decomposition

| New module | LOC | Functions |
|------------|-----|-----------|
| `pyod/utils/_quality_metrics.py` | ~349 | `compute_quality`, `compute_consensus`, `select_best_detector`, `compute_feature_importance`, `feature_contributions` |
| `pyod/utils/_kb_router.py` | ~250 | `evaluate_rules`, `rule_matches`, `eval_condition`, `make_plan`, `suggest_alternative` |
| `pyod/utils/_detector_factory.py` | ~83 | `build_detector_from_plan`, `build_from_preset` |
| `pyod/utils/_nl_feedback.py` | ~237 | `apply_structured_feedback`, `apply_nl_feedback` |

`pyod/utils/ad_engine.py` shrinks from **1,696 to 1,194 LOC** (30% reduction).

Helper modules use leading-underscore names per PyOD convention; they are not part of the public API and external users continue to import only `from pyod.utils.ad_engine import ADEngine`.

## Backwards compatibility

- `inspect.getmembers(ADEngine, callable)` for non-underscore names returns the same 20 entries as v3.2.x.
- `ADEngine.build_detector(self, plan)` preserved as a public method with thin-wrapper body.
- All `quality` dict keys, value formats, and dict shapes are preserved (this PR is structural, not behavioral; PR 1 already changed the stability formula's value).
- Subclass-override surface for the 12 deleted private methods is gone. The leading-underscore contract permits this; no external code in the survey monkey-patches them.

## Tests

- 122/122 tests pass in `pyod/test/test_ad_engine.py` and `pyod/test/test_ad_engine_v3.py`.
- **No test edits.** The `TestStabilityMetric._quality()` adapter from PR 1 transparently switches from the private `engine._compute_quality(...)` to the new `pyod.utils._quality_metrics.compute_quality(...)` because the helper module now imports cleanly.
- `git diff --cached --check` passes (no whitespace warnings).

## Process

- 4 parallel subagents extracted modules concurrently (each writes a different new file; no shared-file conflicts during the parallel phase).
- Orchestrator integrated imports + call sites + thin wrapper sequentially in `ad_engine.py`.
- Plan-reviewed and implement-reviewed by Codex over 2 rounds; both Low findings (unused `spearmanr` import in `analyze()`, partial docstring polish) fixed.

## Spec & plan

- Spec: [docs/superpowers/specs/2026-05-07-adengine-refactor-design.md](docs/superpowers/specs/2026-05-07-adengine-refactor-design.md) Sections 4.1-4.9 cover PR 2.
- Plan: [docs/superpowers/plans/2026-05-07-adengine-refactor-plan.md](docs/superpowers/plans/2026-05-07-adengine-refactor-plan.md) Tasks 2.1-2.5.

## Test plan

- [x] All 122 ADEngine tests pass without modification
- [x] Public method count = 20 (matches v3.2.x)
- [x] `git diff --cached --check` passes
- [x] No subclass/monkey-patch usage of the deleted private methods in the codebase
- [x] Each moved function has NumPy-style Parameters/Returns docstring sections

Depends on: #668 (PR 1 — the bug fix lives in `_compute_quality` body which PR 2 then moves to `_quality_metrics.compute_quality`).