### PR TITLE
docs(lof): correct novelty default in docstring (closes #638)

### DIFF
--- a/pyod/models/lof.py
+++ b/pyod/models/lof.py
@@ -105,12 +105,16 @@ class LOF(BaseDetector):
         If ``-1``, then the number of jobs is set to the number of CPU cores.
         Affects only kneighbors and kneighbors_graph methods.
 
-    novelty : bool (default=False)
-        By default, LocalOutlierFactor is only meant to be used for outlier
-        detection (novelty=False). Set novelty to True if you want to use
-        LocalOutlierFactor for novelty detection. In this case be aware that
-        that you should only use predict, decision_function and score_samples
-        on new unseen data and not on the training set.
+    novelty : bool (default=True)
+        Forwarded to scikit-learn's ``LocalOutlierFactor``. PyOD defaults to
+        ``True`` (the opposite of scikit-learn's default of ``False``)
+        because the PyOD ``BaseDetector`` contract is fit-on-train then
+        ``predict``/``decision_function`` on unseen data, which scikit-learn
+        only permits in novelty mode. Set ``novelty=False`` only if you want
+        to read training-time scores from
+        ``self.detector_.negative_outlier_factor_`` and never call
+        ``predict`` or ``decision_function`` on new data — see scikit-learn's
+        :class:`sklearn.neighbors.LocalOutlierFactor` for details.
 
     Attributes
     ----------

--- a/pyod/test/test_lof.py
+++ b/pyod/test/test_lof.py
@@ -153,6 +153,18 @@ class TestLOF(unittest.TestCase):
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 
+    def test_novelty_default_matches_docstring(self):
+        # Regression for issue #638: the class docstring used to claim
+        # `novelty (default=False)` while __init__ actually defaults to True
+        # (PyOD's BaseDetector contract — fit-then-predict-on-new-data —
+        # requires sklearn's novelty mode). Lock both in sync so they cannot
+        # drift again silently.
+        import inspect
+        sig_default = inspect.signature(LOF.__init__).parameters["novelty"].default
+        self.assertEqual(sig_default, True)
+        # The docstring must declare the same default that __init__ uses.
+        self.assertIn("novelty : bool (default=True)", LOF.__doc__)
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
## Summary

The class-level docstring of `pyod.models.lof.LOF` claimed
`novelty (default=False)`, but `__init__` actually defaults to
`novelty=True`. This PR aligns the docstring with the code, explains *why*
PyOD flips scikit-learn's default, and adds a regression test that locks
the two together so they cannot drift again.

Fixes yzhao062/pyod#638 — *Pyod docs for LOF have typo*

## Context

PyOD's `BaseDetector` contract is fit-on-train then call
`predict` / `decision_function` on unseen data. scikit-learn's
`LocalOutlierFactor` only permits that pattern when `novelty=True`, so
PyOD has always defaulted `novelty=True` (see `pyod/models/lof.py:140`).
The docstring, however, copy-pasted scikit-learn's wording and claimed
`default=False` (see `pyod/models/lof.py:108`). #638 reported the
mismatch.

## Changes

- `pyod/models/lof.py` — docstring now declares `novelty (default=True)`
  and explains the rationale (sklearn's contract + PyOD's API), so a
  future reader doesn't try to "fix" the signature back to `False`.
- `pyod/test/test_lof.py` — new regression test
  `test_novelty_default_matches_docstring` that reads the runtime
  default from `inspect.signature` and asserts the docstring contains
  the matching `(default=True)` line.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/yzhao062/pyod.git /tmp/repro && cd /tmp/repro
python -m venv .venv && . .venv/bin/activate
pip install -e .

# --- BEFORE (origin/master) ---
git checkout origin/master
python -c "
import inspect
from pyod.models.lof import LOF
sig_default = inspect.signature(LOF.__init__).parameters['novelty'].default
print('signature default :', sig_default)
print('docstring claims  :', 'default=True' in LOF.__doc__ and 'True' or 'False')
"
# Expected: signature default = True, docstring claims False  -> MISMATCH (issue #638)

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/pyod.git feat/638-lof-novelty-docstring
git checkout FETCH_HEAD
python -c "
import inspect
from pyod.models.lof import LOF
sig_default = inspect.signature(LOF.__init__).parameters['novelty'].default
print('signature default :', sig_default)
print('docstring claims  :', 'default=True' in LOF.__doc__ and 'True' or 'False')
"
# Expected: signature default = True, docstring claims True   -> MATCH
```

## What I ran locally

- `pytest pyod/test/test_lof.py -x -q` → 18/18 passed (17 prior + 1 new
  regression test).
- The new test, run against unmodified `master`, fails on the docstring
  assertion (verified by stashing `pyod/models/lof.py` and re-running).

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Behavior unchanged | `LOF()` → fit → predict on new data | works (novelty mode) | existing `test_prediction_scores`, `test_prediction_labels` |
| 2 | Docs-vs-code consistency | `inspect.signature(LOF.__init__).parameters['novelty'].default` vs `LOF.__doc__` | both report `True` | new `test_novelty_default_matches_docstring` |
| 3 | `clone` round-trip | `sklearn.base.clone(LOF())` | preserves default | existing `test_model_clone` |

## Risk / blast radius

Documentation-only change plus one regression test. No behavior change.
The runtime default has been `True` since this wrapper was added; only
the docstring shifts.

## Release note

```release-note
docs(lof): correct the default value of `novelty` shown in the LOF docstring (was `False`, actually `True`); behavior unchanged.
```

---

### PR template checklist (per `PULL_REQUEST_TEMPLATE.md`)

- [x] Followed CONTRIBUTING guidance (small, focused, with test).
- [x] No other open PRs for this change (searched repo).
- [x] Linked to a specific issue: #638.
- [x] Explanation included above.
- [x] New regression test added (`test_novelty_default_matches_docstring`).
- [x] Tests run locally: `pytest pyod/test/test_lof.py -x -q` → 18 passed.
- [ ] CI (CircleCI / Travis / AppVeyor): will be exercised by repo workflows once the PR runs.
- [x] Code coverage: net-positive (one new test, no removed lines of executable code).
- [x] Lint: docstring-only change in module, plus a small test method.

---

*PR drafted with assistance from Claude Code (Anthropic). The change was
reviewed manually against the pyod source and the scikit-learn
`LocalOutlierFactor` contract cited above. The reproducer block above is
the one I used during development; reviewers can paste it verbatim.*