### PR TITLE
Fix DataFrame feature name warnings in sklearn wrapper models (#540)

### DIFF
--- a/pyod/models/gmm.py
+++ b/pyod/models/gmm.py
@@ -219,6 +219,7 @@ class GMM(BaseDetector):
             The anomaly score of the input samples.
         """
         check_is_fitted(self, ["decision_scores_", "threshold_", "labels_"])
+        X = check_array(X)
 
         # Invert outlier scores. Outliers come with higher outlier scores
         return invert_order(self.detector_.score_samples(X))

--- a/pyod/models/iforest.py
+++ b/pyod/models/iforest.py
@@ -241,6 +241,7 @@ class IForest(BaseDetector):
             The anomaly score of the input samples.
         """
         check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
+        X = check_array(X)
         # invert outlier scores. Outliers comes with higher outlier scores
         return invert_order(self.detector_.decision_function(X))
 

--- a/pyod/models/lof.py
+++ b/pyod/models/lof.py
@@ -211,6 +211,7 @@ class LOF(BaseDetector):
 
         check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
 
+        X = check_array(X)
         # Invert outlier scores. Outliers comes with higher outlier scores
         # noinspection PyProtectedMember
         try:

--- a/pyod/models/lof.py
+++ b/pyod/models/lof.py
@@ -211,7 +211,7 @@ class LOF(BaseDetector):
 
         check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
 
-        X = check_array(X)
+        X = check_array(X, accept_sparse=True)
         # Invert outlier scores. Outliers comes with higher outlier scores
         # noinspection PyProtectedMember
         try:

--- a/pyod/models/ocsvm.py
+++ b/pyod/models/ocsvm.py
@@ -188,6 +188,7 @@ class OCSVM(BaseDetector):
             The anomaly score of the input samples.
         """
         check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
+        X = check_array(X)
         # Invert outlier scores. Outliers comes with higher outlier scores
         return invert_order(self.detector_.decision_function(X))
 

--- a/pyod/test/test_iforest.py
+++ b/pyod/test/test_iforest.py
@@ -167,6 +167,27 @@ class TestIForest(unittest.TestCase):
         feature_importances = self.clf.feature_importances_
         assert (len(feature_importances) == 2)
 
+    def test_dataframe_no_feature_name_warning(self):
+        """Regression test for GitHub issue #540.
+
+        When a pandas DataFrame is passed to fit/predict, no warning about
+        feature names should be raised by the underlying sklearn estimator.
+        """
+        import pandas as pd
+        import warnings
+
+        df_train = pd.DataFrame(self.X_train, columns=['f1', 'f2'])
+        df_test = pd.DataFrame(self.X_test, columns=['f1', 'f2'])
+
+        clf = IForest(contamination=self.contamination, random_state=42)
+        clf.fit(df_train)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            clf.decision_function(df_test)
+            clf.predict(df_test)
+            clf.predict_proba(df_test)
+
     def tearDown(self):
         pass
 

--- a/pyod/test/test_iforest.py
+++ b/pyod/test/test_iforest.py
@@ -173,8 +173,10 @@ class TestIForest(unittest.TestCase):
         When a pandas DataFrame is passed to fit/predict, no warning about
         feature names should be raised by the underlying sklearn estimator.
         """
-        import pandas as pd
+        import pytest
         import warnings
+
+        pd = pytest.importorskip("pandas")
 
         df_train = pd.DataFrame(self.X_train, columns=['f1', 'f2'])
         df_test = pd.DataFrame(self.X_test, columns=['f1', 'f2'])

--- a/pyod/test/test_lof.py
+++ b/pyod/test/test_lof.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_allclose
 from numpy.testing import assert_array_less
 from numpy.testing import assert_equal
 from numpy.testing import assert_raises
+from scipy.sparse import csr_matrix
 from scipy.stats import rankdata
 from sklearn.base import clone
 from sklearn.metrics import roc_auc_score
@@ -60,6 +61,16 @@ class TestLOF(unittest.TestCase):
 
         # check performance
         assert (roc_auc_score(self.y_test, pred_scores) >= self.roc_floor)
+
+    def test_sparse_prediction_scores(self):
+        sparse_train = csr_matrix(self.X_train)
+        sparse_test = csr_matrix(self.X_test)
+        clf = LOF(contamination=self.contamination)
+        clf.fit(sparse_train)
+
+        pred_scores = clf.decision_function(sparse_test)
+
+        assert_equal(pred_scores.shape[0], self.X_test.shape[0])
 
     def test_prediction_labels(self):
         pred_labels = self.clf.predict(self.X_test)


### PR DESCRIPTION
### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

---

**Closes #540**

#### What does this PR do?

Adds `X = check_array(X)` to `decision_function()` in four sklearn-wrapper models (`IForest`, `OCSVM`, `LOF`, `GMM`) that were missing input validation. This prevents the `UserWarning: X has feature names, but <Model> was fitted without feature names` warning when using pandas DataFrames.

**Root cause:** `fit()` already calls `check_array(X)`, which strips DataFrame column names before fitting the underlying sklearn estimator. But `decision_function()` was passing the raw DataFrame directly to sklearn at predict time, causing a feature-name mismatch warning.

Three other wrapper models (`MCD`, `PCA`, `HDBSCAN`) already had `check_array(X)` in their `decision_function()` and were unaffected.

#### Changes
- `pyod/models/iforest.py` — add `X = check_array(X)` in `decision_function()`
- `pyod/models/ocsvm.py` — same
- `pyod/models/lof.py` — same
- `pyod/models/gmm.py` — same
- `pyod/test/test_iforest.py` — add regression test `test_dataframe_no_feature_name_warning`