### PR TITLE
fix: fall back to HuggingFace for local encoder paths when sentence-transformers is absent

### DIFF
--- a/pyod/test/test_embedding.py
+++ b/pyod/test/test_embedding.py
@@ -552,5 +552,124 @@ class TestAirGappedAndPreinstantiated(unittest.TestCase):
         self.assertNotIsInstance(enc, CallableEncoder)
 
 
+class TestLocalPathEncoderFallback(unittest.TestCase):
+
+    def test_local_path_falls_back_to_huggingface(self):
+        """A local path falls back to the HuggingFace backend when
+        sentence-transformers is unavailable, instead of raising."""
+        import tempfile
+        from unittest.mock import patch
+        import pyod.utils.encoders as enc
+
+        sentinel = object()
+
+        def fake_create(backend, **kwargs):
+            if backend == 'sentence_transformer':
+                raise ImportError("sentence-transformers not installed")
+            if backend == 'huggingface':
+                return sentinel
+            raise AssertionError("unexpected backend: %s" % backend)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(enc, '_create_encoder',
+                              side_effect=fake_create):
+                resolved = enc.resolve_encoder(tmpdir)
+
+        self.assertIs(resolved, sentinel)
+
+    def test_local_path_uses_sentence_transformer_when_available(self):
+        """Local path uses the SentenceTransformer backend when available."""
+        import tempfile
+        from unittest.mock import patch
+        import pyod.utils.encoders as enc
+
+        sentinel = object()
+        seen = []
+
+        def fake_create(backend, **kwargs):
+            seen.append(backend)
+            if backend == 'sentence_transformer':
+                return sentinel
+            raise AssertionError("should not reach: %s" % backend)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(enc, '_create_encoder', side_effect=fake_create):
+                resolved = enc.resolve_encoder(tmpdir)
+
+        self.assertIs(resolved, sentinel)
+        self.assertEqual(seen, ['sentence_transformer'])
+
+    def test_local_path_no_backend_raises_importerror(self):
+        """Local path with neither backend installed raises ImportError."""
+        import tempfile
+        from unittest.mock import patch
+        import pyod.utils.encoders as enc
+
+        def fake_create(backend, **kwargs):
+            raise ImportError("backend not installed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(enc, '_create_encoder', side_effect=fake_create):
+                with self.assertRaises(ImportError):
+                    enc.resolve_encoder(tmpdir)
+
+
+class _FakeST:
+    """Stand-in for SentenceTransformer; no torch/ST install required."""
+
+    def __init__(self, model_name=None, device=None, **kwargs):
+        self.kwargs = kwargs
+
+    def encode(self, X, **kw):
+        import numpy as np
+        return np.zeros((len(X), 4), dtype=float)
+
+
+class TestSentenceTransformerEncoderLoading(unittest.TestCase):
+
+    def test_local_path_loads_with_local_files_only(self):
+        import tempfile
+        from unittest.mock import patch
+        import pyod.utils.encoders.sentence_transformer as st_mod
+        from pyod.utils.encoders.sentence_transformer import (
+            SentenceTransformerEncoder)
+        with patch.object(st_mod, 'SentenceTransformer', _FakeST):
+            with tempfile.TemporaryDirectory() as d:
+                enc = SentenceTransformerEncoder(d)
+                enc.encode(["a", "b"])
+                self.assertTrue(enc.model_.kwargs.get('local_files_only'))
+
+    def test_remote_name_loads_without_local_flag(self):
+        from unittest.mock import patch
+        import pyod.utils.encoders.sentence_transformer as st_mod
+        from pyod.utils.encoders.sentence_transformer import (
+            SentenceTransformerEncoder)
+        with patch.object(st_mod, 'SentenceTransformer', _FakeST):
+            enc = SentenceTransformerEncoder("some-remote-model")
+            enc.encode(["a"])
+            self.assertNotIn('local_files_only', enc.model_.kwargs)
+
+    def test_preinstantiated_object_is_reused(self):
+        from unittest.mock import patch
+        import pyod.utils.encoders.sentence_transformer as st_mod
+        from pyod.utils.encoders.sentence_transformer import (
+            SentenceTransformerEncoder)
+        with patch.object(st_mod, 'SentenceTransformer', _FakeST):
+            model = _FakeST()
+            enc = SentenceTransformerEncoder(model)
+            enc.encode(["a"])
+            self.assertIs(enc.model_, model)
+
+    def test_invalid_model_name_type_raises(self):
+        from unittest.mock import patch
+        import pyod.utils.encoders.sentence_transformer as st_mod
+        from pyod.utils.encoders.sentence_transformer import (
+            SentenceTransformerEncoder)
+        with patch.object(st_mod, 'SentenceTransformer', _FakeST):
+            enc = SentenceTransformerEncoder(42)
+            with self.assertRaises(TypeError):
+                enc.encode(["a"])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyod/utils/encoders/__init__.py
+++ b/pyod/utils/encoders/__init__.py
@@ -382,8 +382,27 @@ def resolve_encoder(encoder):
         # with local_files_only=True rather than resolved as a Hub ID.
         import os
         if os.path.exists(encoder):
-            return _create_encoder('sentence_transformer',
-                                   model_name=encoder)
+            # Local path: prefer the SentenceTransformer backend, but fall
+            # back to HuggingFace when sentence-transformers isn't installed
+            # (e.g. a pyod[huggingface]-only environment). Both backends load
+            # from a local directory without any network/Hub call.
+            try:
+                return _create_encoder('sentence_transformer',
+                                       model_name=encoder)
+            except ImportError:
+                pass
+
+            try:
+                return _create_encoder('huggingface',
+                                       model_name=encoder,
+                                       modality='text')
+            except ImportError:
+                pass
+
+            raise ImportError(
+                "Loading a local encoder path requires sentence-transformers "
+                "or transformers. Install with: pip install pyod[embedding] "
+                "or pip install pyod[huggingface].")
 
         # Check registry
         if encoder in _ENCODER_REGISTRY:


### PR DESCRIPTION
Follow-up to #696. Resolves the Codex review comment on release PR #700.

Problem
-------
In resolve_encoder, the local-path branch forced the SentenceTransformer backend unconditionally. On a pyod[huggingface]-only install (no sentence-transformers), passing a local model path raised ImportError before the existing HuggingFace fallback could run - a regression for local-path usage in HF-only environments.

Fix
---
The local-path branch now tries the SentenceTransformer backend first and, on ImportError, falls back to the HuggingFace backend (mirroring the existing auto-resolve pattern below it). If neither backend is available it raises a clear ImportError with install hints. Both backends load from a local directory without any Hub/network call.

Tests
-----
Adds TestLocalPathEncoderFallback (resolver fallback control flow with _create_encoder mocked) and TestSentenceTransformerEncoderLoading (encoder local-path / remote / pre-instantiated / bad-type loading branches via a fake SentenceTransformer). All new tests run without sentence-transformers or torch installed.

No breaking API changes.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.