### PR TITLE
Fix DeepSVDD not training due to disabled backward pass

### DIFF
--- a/pyod/models/deep_svdd.py
+++ b/pyod/models/deep_svdd.py
@@ -6,6 +6,8 @@
 # License: BSD 2 clause
 
 
+import copy
+
 import numpy as np
 
 try:
@@ -361,7 +363,11 @@ class DeepSVDD(BaseDetector):
             # the batch loop, not inside it)
             if epoch_loss < best_loss:
                 best_loss = epoch_loss
-                best_model_dict = self.model_.state_dict()
+                # state_dict() returns references to the live parameters, so
+                # a later optimizer.step() would mutate this snapshot in
+                # place and leave the final weights here instead of the best
+                # ones. Copy it.
+                best_model_dict = copy.deepcopy(self.model_.state_dict())
             print(f"Epoch {epoch + 1}/{self.epochs}, Loss: {epoch_loss}")
         self.best_model_dict = best_model_dict
 

--- a/pyod/models/deep_svdd.py
+++ b/pyod/models/deep_svdd.py
@@ -336,9 +336,6 @@ class DeepSVDD(BaseDetector):
 
         optimizer = optimizer_dict[self.optimizer](self.model_.parameters(),
                                                    weight_decay=self.l2_regularizer)
-        w_d = 1e-6 * sum(
-            [torch.linalg.norm(w) for w in self.model_.parameters()])
-
         for epoch in range(self.epochs):
             self.model_.train()
             epoch_loss = 0
@@ -346,18 +343,25 @@ class DeepSVDD(BaseDetector):
                 optimizer.zero_grad()
                 outputs = self.model_(batch_x)
                 dist = torch.sum((outputs - self.c) ** 2, dim=-1)
+                # L2 regularization term, recomputed every step so that it
+                # is part of the current batch's computation graph
+                w_d = 1e-6 * sum(
+                    [torch.linalg.norm(w) for w in self.model_.parameters()])
                 if self.use_ae:
                     loss = torch.mean(dist) + w_d + torch.mean(
                         torch.square(outputs - batch_x))
                 else:
                     loss = torch.mean(dist) + w_d
 
-                # loss.backward()
+                loss.backward()
                 optimizer.step()
                 epoch_loss += loss.item()
-                if epoch_loss < best_loss:
-                    best_loss = epoch_loss
-                    best_model_dict = self.model_.state_dict()
+            # keep the best performing model across epochs (epoch_loss is the
+            # accumulated loss over the whole epoch, so this must run after
+            # the batch loop, not inside it)
+            if epoch_loss < best_loss:
+                best_loss = epoch_loss
+                best_model_dict = self.model_.state_dict()
             print(f"Epoch {epoch + 1}/{self.epochs}, Loss: {epoch_loss}")
         self.best_model_dict = best_model_dict
 


### PR DESCRIPTION
### Problem

In `DeepSVDD.fit()` the training loop had `loss.backward()` commented out (issue #606):

```python
                # loss.backward()
                optimizer.step()
```

With no backward pass, gradients are never computed, so `optimizer.step()` is a no-op — the network never learns and the anomaly scores come from the randomly initialised weights.

Simply uncommenting the line raises the error reported in #606:

```
RuntimeError: Trying to backward through the graph a second time ...
```

because the L2 penalty term `w_d` was built **once before** the epoch loop and then added to every batch's loss, so the second `backward()` re-traverses its already-freed graph.

### Fix

- Recompute `w_d` **inside** the batch loop, so it belongs to the current batch's graph (resolves the double-backward error).
- Uncomment `loss.backward()`.
- Move the best-model bookkeeping **out** of the batch loop (issue #641): `epoch_loss` accumulates over the whole epoch, so comparing it to `best_loss` after every batch saved an early-in-epoch state instead of the best epoch.

### Verification

On synthetic data (`generate_data`, 10 features, 10% contamination), scoring on a held-out set:

| | epoch 1 | epoch 5 | epoch 20 | epoch 40 | trains? |
|---|---|---|---|---|---|
| master (backward commented) | 8.79 | 9.05 | 8.83 | 8.91 | no (flat) |
| **this PR** | 4.53 | 0.09 | 0.003 | 0.000 | **yes** |

The training loss now decreases smoothly instead of staying flat, `pyod/test/test_deepsvdd.py` passes (15/15), and ROC AUC is unaffected (~0.998).

### Note

`best_model_dict` is still not loaded back into `model_` by `decision_function` (scoring uses the final-epoch weights). I left that behaviour unchanged so this PR stays focused on the training bug, but I'm happy to wire it in as a follow-up if you'd like.
