### PR TITLE
Add pyod.dev website badge, brand logo, and security policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,18 @@
+.. image:: brand/pyod-icon.svg
+   :target: https://pyod.dev
+   :alt: PyOD Ecosystem
+   :width: 84px
+
 Python Outlier Detection (PyOD) 3
 ==================================
 
 **PyOD 3: Agentic Anomaly Detection At Scale**
 
-|badge_pypi| |badge_anaconda| |badge_docs| |badge_stars| |badge_forks| |badge_downloads| |badge_testing| |badge_coverage| |badge_maintainability| |badge_license| |badge_benchmark|
+|badge_website| |badge_pypi| |badge_anaconda| |badge_docs| |badge_stars| |badge_forks| |badge_downloads| |badge_testing| |badge_coverage| |badge_maintainability| |badge_license| |badge_benchmark|
+
+.. |badge_website| image:: https://img.shields.io/badge/website-pyod.dev-990000
+   :target: https://pyod.dev
+   :alt: Website
 
 .. |badge_pypi| image:: https://img.shields.io/pypi/v/pyod.svg?color=brightgreen
    :target: https://pypi.org/project/pyod/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+PyOD is used across production systems for anomaly detection. We treat security reports
+with priority and handle them through coordinated disclosure.
+
+## Supported Versions
+
+Security fixes land on the latest released version of PyOD. Please upgrade to the current
+release before reporting, in case the issue is already resolved.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately through GitHub's private vulnerability reporting.
+Do not open a public issue for a security problem.
+
+Under the **Security** tab of this repository, select **Report a vulnerability**.
+
+Include the affected version, a description of the problem, the impact, and a minimal
+reproduction or proof of concept if you have one.
+
+## What to Expect
+
+- We aim to acknowledge a report within three business days.
+- We will confirm the issue, assess its severity, and keep you updated while we prepare a
+  fix.
+- Please keep the report private while we investigate. We aim to remediate within 90 days
+  and will coordinate the disclosure date with you; any extension will be agreed together.
+- With your consent, we credit reporters in the release notes and the published advisory.
+
+## Scope
+
+In scope: the PyOD source code, including the model and artifact loading paths,
+deserialization (for example ``pyod.utils.persistence``), and release integrity.
+
+Out of scope: vulnerabilities in third-party dependencies (report those upstream), issues
+that require an already-compromised local environment, and findings against unsupported or
+modified versions.

--- a/brand/README.md
+++ b/brand/README.md
@@ -1,0 +1,14 @@
+# PyOD Brand Assets
+
+Logo and mark files for the PyOD ecosystem. The palette is cardinal `#990000` (the
+flagged outlier) and navy `#2b5597` (the inlier distribution), matching
+[pyod.dev](https://pyod.dev).
+
+| File | Use |
+|---|---|
+| `pyod-icon.svg` | App-style icon on a light rounded tile. Stays legible on any background; used in the README header. |
+| `pyod-mark.svg` / `pyod-mark-dark.svg` | Transparent mark (ring plus outlier dot). Use the `-dark` variant on dark backgrounds. |
+| `pyod-logo.svg` / `pyod-logo-dark.svg` | Mark plus the "PyOD" wordmark. Use the `-dark` variant on dark backgrounds. |
+
+The wordmark in the logo files uses a system monospace font. For a fixed rendering
+everywhere, outline the text to paths before export.

--- a/brand/pyod-icon.svg
+++ b/brand/pyod-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <rect width="64" height="64" rx="15" fill="#fdf7f5"/>
+  <circle cx="26" cy="39" r="16.5" fill="none" stroke="#2b5597" stroke-width="4"/>
+  <circle cx="47" cy="18" r="7.5" fill="#990000"/>
+</svg>

--- a/brand/pyod-logo-dark.svg
+++ b/brand/pyod-logo-dark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 168 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <circle cx="25" cy="39" r="19" fill="none" stroke="#7aa6e0" stroke-width="4.5"/>
+  <circle cx="50" cy="16" r="8.5" fill="#e0655c"/>
+  <text x="68" y="45" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="33" font-weight="700" fill="#f2e8e6">PyOD</text>
+</svg>

--- a/brand/pyod-logo.svg
+++ b/brand/pyod-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 168 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <circle cx="25" cy="39" r="19" fill="none" stroke="#2b5597" stroke-width="4.5"/>
+  <circle cx="50" cy="16" r="8.5" fill="#990000"/>
+  <text x="68" y="45" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="33" font-weight="700" fill="#2a1c1c">PyOD</text>
+</svg>

--- a/brand/pyod-mark-dark.svg
+++ b/brand/pyod-mark-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <circle cx="25" cy="39" r="19" fill="none" stroke="#7aa6e0" stroke-width="4.5"/>
+  <circle cx="50" cy="16" r="8.5" fill="#e0655c"/>
+</svg>

--- a/brand/pyod-mark.svg
+++ b/brand/pyod-mark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <circle cx="25" cy="39" r="19" fill="none" stroke="#2b5597" stroke-width="4.5"/>
+  <circle cx="50" cy="16" r="8.5" fill="#990000"/>
+</svg>

--- a/docs/_static/pyod-icon.svg
+++ b/docs/_static/pyod-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <rect width="64" height="64" rx="15" fill="#fdf7f5"/>
+  <circle cx="26" cy="39" r="16.5" fill="none" stroke="#2b5597" stroke-width="4"/>
+  <circle cx="47" cy="18" r="7.5" fill="#990000"/>
+</svg>

--- a/docs/_static/pyod-mark-dark.svg
+++ b/docs/_static/pyod-mark-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <circle cx="25" cy="39" r="19" fill="none" stroke="#7aa6e0" stroke-width="4.5"/>
+  <circle cx="50" cy="16" r="8.5" fill="#e0655c"/>
+</svg>

--- a/docs/_static/pyod-mark.svg
+++ b/docs/_static/pyod-mark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="PyOD">
+  <title>PyOD</title>
+  <circle cx="25" cy="39" r="19" fill="none" stroke="#2b5597" stroke-width="4.5"/>
+  <circle cx="50" cy="16" r="8.5" fill="#990000"/>
+</svg>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,12 +94,16 @@ html_theme = "furo"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "light_logo": "pyod-mark.svg",
+    "dark_logo": "pyod-mark-dark.svg",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static"]
+html_favicon = "_static/pyod-icon.svg"
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
## What

Give PyOD a visible tie to the new ecosystem site (pyod.dev) and its first logo.

- **README**: a `website` badge linking to https://pyod.dev, plus a small header logo icon.
- **`brand/`**: logo assets (mark, wordmark, app icon; light + dark) with a usage `brand/README.md`.
- **docs (Furo)**: light/dark sidebar logo (`light_logo` / `dark_logo`) and a favicon.
- **`SECURITY.md`**: private reporting (GitHub private vulnerability reporting, now enabled) plus a coordinated-disclosure policy.

## Notes

- README diff is minimal; the file's CRLF line endings are preserved, no unrelated churn.
- Reviewed with Codex (implement-review); all findings addressed: removed the RST `:align` that GitHub ignores, tightened the disclosure-window wording, and documented the brand variants.
- Docs logo verified with a Furo `sphinx-build` (light/dark sidebar logo and favicon render).
