### PR TITLE
Make LOCI honor contamination and keep k as a parameter

### DIFF
--- a/pyod/models/loci.py
+++ b/pyod/models/loci.py
@@ -140,13 +140,13 @@ class LOCI(BaseDetector):
     ...     contamination=contamination, random_state=42)
     >>> clf = LOCI()
     >>> clf.fit(X_train)
-    LOCI(alpha=0.5, contamination=0.1, k=None)
+    LOCI(alpha=0.5, contamination=0.1, k=3)
     """
 
     def __init__(self, contamination=0.1, alpha=0.5, k=3):
         super(LOCI, self).__init__(contamination=contamination)
         self.alpha = alpha
-        self.threshold_ = k
+        self.k = k
 
     def _get_alpha_n(self, dist_matrix, indices, r):
         """Computes the alpha neighbourhood points.
@@ -208,7 +208,7 @@ class LOCI(BaseDetector):
                 sigma_mdef = np.std(n_values) / n_hat
                 if n_hat >= 20:
                     outlier_scores[p_ix] = mdef / sigma_mdef
-                    if mdef > (self.threshold_ * sigma_mdef):
+                    if mdef > (self.k * sigma_mdef):
                         break
         return np.asarray(outlier_scores)
 
@@ -231,13 +231,8 @@ class LOCI(BaseDetector):
         X = check_array(X)
         self._set_n_classes(y)
         self.decision_scores_ = self._calculate_decision_score(X)
-        self.labels_ = (self.decision_scores_ > self.threshold_).astype(
-            'int').ravel()
+        self._process_decision_scores()
 
-        # calculate for predict_proba()
-
-        self._mu = np.mean(self.decision_scores_)
-        self._sigma = np.std(self.decision_scores_)
         return self
 
     def decision_function(self, X):

--- a/pyod/test/test_loci.py
+++ b/pyod/test/test_loci.py
@@ -148,6 +148,32 @@ class TestLOCI(unittest.TestCase):
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 
+    def test_k_is_stored_as_parameter(self):
+        # `k` must survive as a constructor attribute so that get_params /
+        # clone round-trip it (issue #194).
+        clf = LOCI(contamination=self.contamination, k=5)
+        assert_equal(clf.k, 5)
+        assert_equal(clone(clf).k, 5)
+
+    def test_contamination_controls_labels(self):
+        # `threshold_` is documented as being derived from `contamination`,
+        # so a larger contamination must flag at least as many outliers
+        # (issue #194).
+        fractions = []
+        for contamination in (0.05, 0.25, 0.45):
+            clf = LOCI(contamination=contamination)
+            clf.fit(self.X_train)
+            fractions.append(clf.labels_.mean())
+        assert_array_less(fractions[0], fractions[1])
+        assert_array_less(fractions[1], fractions[2])
+
+    def test_threshold_matches_contamination(self):
+        # labels_ must select ~contamination of the training samples.
+        contamination = 0.25
+        clf = LOCI(contamination=contamination)
+        clf.fit(self.X_train)
+        assert_allclose(clf.labels_.mean(), contamination, atol=0.02)
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
`LOCI` accepts a `contamination` argument and documents `threshold_` as "based on
``contamination`` ... the ``n_samples * contamination`` most abnormal samples", but
the value never reaches the thresholding logic. In `__init__` the *other* parameter,
`k`, is written straight into `self.threshold_`:

```python
def __init__(self, contamination=0.1, alpha=0.5, k=3):
    super(LOCI, self).__init__(contamination=contamination)
    self.alpha = alpha
    self.threshold_ = k        # <- k, not contamination
```

and `fit()` then labels against that same `k`, so `contamination` is dead weight.
Sweeping it changes nothing:

```
contamination=0.05  -> outlier frac=0.1583   threshold_=3
contamination=0.1   -> outlier frac=0.1583   threshold_=3
contamination=0.2   -> outlier frac=0.1583   threshold_=3
contamination=0.3   -> outlier frac=0.1583   threshold_=3
contamination=0.45  -> outlier frac=0.1583   threshold_=3
```

There's a second consequence of the same line. Because `k` is consumed instead of
stored, `LOCI` has no `k` attribute, so scikit-learn's `get_params` falls back to
`None` and a cloned estimator is silently broken:

```python
>>> clf = LOCI(k=5)
>>> hasattr(clf, "k")
False
>>> clone(clf).fit(X)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```

The existing `test_model_clone` doesn't catch this because it only clones, it never
fits the clone.

## What this changes

Three small edits, all in `loci.py`:

- `__init__` stores `self.k = k` instead of overwriting `threshold_`.
- The score loop's early-break test uses `self.k` — that's the outlier cutoff `k`
  is documented to be, and it's the only place it was ever really used.
- `fit()` calls `self._process_decision_scores()` instead of hand-rolling
  `labels_`/`_mu`/`_sigma`. That's the base-class helper every other detector in
  the package uses (`lof`, `cof`, `sod`, ...), and it derives `threshold_` from
  `contamination` via the documented percentile rule.

The stale `k=None` in the class docstring's example repr is updated to `k=3` to
match the actual default.

Scores are untouched — `decision_function` and `_calculate_decision_score` compute
exactly what they did before for a given `k`. Only the threshold used to turn those
scores into binary labels changes, which is the reported bug.

## Testing

Ran the module's suite in a clean venv (numpy/scipy/scikit-learn/numba, `pip install -e .`):

```
$ python -m pytest pyod/test/test_loci.py -q
20 passed, 7 warnings in 138.83s
```

That includes three new cases added to `TestLOCI`, each of which fails on `master`
before the change:

- `test_k_is_stored_as_parameter` — `AttributeError: 'LOCI' object has no attribute 'k'`
- `test_contamination_controls_labels` — all three contamination values produced the
  identical outlier fraction
- `test_threshold_matches_contamination` — `ACTUAL: 0.14  DESIRED: 0.25`

After the change the same sweep tracks the requested rate:

```
contamination=0.05  -> outlier frac=0.0500
contamination=0.1   -> outlier frac=0.1000
contamination=0.2   -> outlier frac=0.2000
contamination=0.3   -> outlier frac=0.3000
contamination=0.45  -> outlier frac=0.4500
```

Detection quality is unchanged on the standard synthetic benchmark (train ROC 0.959,
test ROC 0.963 at `contamination=0.1`), and `k` still visibly drives the scores
(`k=1/3/10` give mean scores 0.519/0.506/0.240), confirming it kept its real role.

Also ran `pyod/test/test_base.py`, `test_data.py` and `test_utility.py` (39 passed)
since `fit()` now routes through the shared base-class path. `flake8 --max-line-length=127`
on both touched files reports the same 25 pre-existing violations as on `master` —
no new ones.

Fixes #194
