### PR TITLE
fix(cblof): store n_jobs so get_params() and clone() carry it over

### DIFF
--- a/pyod/models/cblof.py
+++ b/pyod/models/cblof.py
@@ -187,7 +187,8 @@ class CBLOF(BaseDetector):
         # deprecated and emits FutureWarning for any concrete value, including
         # the default 1.  Only forward when the user explicitly requested more
         # than one job so that plain CBLOF().fit(X) stays warning-free.
-        if (self.n_jobs != 1
+        if (self.clustering_estimator is None
+                and self.n_jobs != 1
                 and "n_jobs" in inspect.signature(KMeans.__init__).parameters):
             _kmeans_kwargs["n_jobs"] = self.n_jobs
         self._validate_estimator(default=KMeans(**_kmeans_kwargs))

--- a/pyod/models/cblof.py
+++ b/pyod/models/cblof.py
@@ -92,10 +92,13 @@ class CBLOF(BaseDetector):
         RandomState instance used by `np.random`.
 
     n_jobs : int, optional (default=1)
-        Accepted for API compatibility but currently unused: the value is
-        neither stored on the estimator nor forwarded to the clustering
-        step, so ``get_params()`` reports ``None`` for it and ``clone()``
-        does not carry it over. See issue #713.
+        Number of parallel jobs passed to the default KMeans clustering
+        backend. Has no effect when a custom ``clustering_estimator`` is
+        provided (pass ``n_jobs`` directly to that estimator instead).
+        Note: ``sklearn.cluster.KMeans`` removed the ``n_jobs`` parameter
+        in version 0.25; on sklearn >= 0.25 this argument is stored for
+        ``get_params()`` / ``clone()`` compatibility but is silently
+        ignored by the underlying KMeans call.
 
     Attributes
     ----------
@@ -149,6 +152,7 @@ class CBLOF(BaseDetector):
         self.use_weights = use_weights
         self.check_estimator = check_estimator
         self.random_state = random_state
+        self.n_jobs = n_jobs
 
     # noinspection PyIncorrectDocstring
     def fit(self, X, y=None):

--- a/pyod/models/cblof.py
+++ b/pyod/models/cblof.py
@@ -94,10 +94,11 @@ class CBLOF(BaseDetector):
 
     n_jobs : int, optional (default=1)
         Number of parallel jobs for the default KMeans backend.
-        Forwarded to ``KMeans`` on scikit-learn versions that support it
-        (the parameter was removed in sklearn 0.25).  On sklearn >= 0.25
-        this value is stored for ``get_params()`` / ``clone()``
-        compatibility only and has no effect on the clustering step.
+        Only forwarded to ``KMeans`` when set to a value other than 1
+        *and* the installed scikit-learn version supports it (the
+        parameter was deprecated in 0.23 and removed in 0.25).
+        On sklearn >= 0.25, or when left at the default of 1, this value
+        is stored for ``get_params()`` / ``clone()`` compatibility only.
         Has no effect when a custom ``clustering_estimator`` is provided;
         set ``n_jobs`` on that estimator directly.
 
@@ -182,7 +183,12 @@ class CBLOF(BaseDetector):
         # number of clusters are default to 8
         _kmeans_kwargs = dict(
             n_clusters=self.n_clusters, random_state=self.random_state)
-        if "n_jobs" in inspect.signature(KMeans.__init__).parameters:
+        # n_jobs was removed from KMeans in sklearn 0.25; on 0.23/0.24 it is
+        # deprecated and emits FutureWarning for any concrete value, including
+        # the default 1.  Only forward when the user explicitly requested more
+        # than one job so that plain CBLOF().fit(X) stays warning-free.
+        if (self.n_jobs != 1
+                and "n_jobs" in inspect.signature(KMeans.__init__).parameters):
             _kmeans_kwargs["n_jobs"] = self.n_jobs
         self._validate_estimator(default=KMeans(**_kmeans_kwargs))
 

--- a/pyod/models/cblof.py
+++ b/pyod/models/cblof.py
@@ -6,6 +6,7 @@
 # License: BSD 2 clause
 
 
+import inspect
 import warnings
 
 import numpy as np
@@ -92,13 +93,13 @@ class CBLOF(BaseDetector):
         RandomState instance used by `np.random`.
 
     n_jobs : int, optional (default=1)
-        Number of parallel jobs passed to the default KMeans clustering
-        backend. Has no effect when a custom ``clustering_estimator`` is
-        provided (pass ``n_jobs`` directly to that estimator instead).
-        Note: ``sklearn.cluster.KMeans`` removed the ``n_jobs`` parameter
-        in version 0.25; on sklearn >= 0.25 this argument is stored for
-        ``get_params()`` / ``clone()`` compatibility but is silently
-        ignored by the underlying KMeans call.
+        Number of parallel jobs for the default KMeans backend.
+        Forwarded to ``KMeans`` on scikit-learn versions that support it
+        (the parameter was removed in sklearn 0.25).  On sklearn >= 0.25
+        this value is stored for ``get_params()`` / ``clone()``
+        compatibility only and has no effect on the clustering step.
+        Has no effect when a custom ``clustering_estimator`` is provided;
+        set ``n_jobs`` on that estimator directly.
 
     Attributes
     ----------
@@ -179,9 +180,11 @@ class CBLOF(BaseDetector):
 
         # check parameters
         # number of clusters are default to 8
-        self._validate_estimator(default=KMeans(
-            n_clusters=self.n_clusters,
-            random_state=self.random_state))
+        _kmeans_kwargs = dict(
+            n_clusters=self.n_clusters, random_state=self.random_state)
+        if "n_jobs" in inspect.signature(KMeans.__init__).parameters:
+            _kmeans_kwargs["n_jobs"] = self.n_jobs
+        self._validate_estimator(default=KMeans(**_kmeans_kwargs))
 
         self.clustering_estimator_.fit(X=X, y=y)
         # Get the labels of the clustering results

--- a/pyod/test/test_cblof.py
+++ b/pyod/test/test_cblof.py
@@ -166,6 +166,28 @@ class TestCBLOF(unittest.TestCase):
     def test_model_clone(self):
         clone_clf = clone(self.clf)
 
+    def test_n_jobs_stored(self):
+        # n_jobs must be stored so get_params() and clone() carry it over
+        clf = CBLOF(n_jobs=4)
+        assert clf.n_jobs == 4
+        assert clf.get_params()['n_jobs'] == 4
+
+    def test_n_jobs_clone(self):
+        clf = CBLOF(n_jobs=4)
+        cloned = clone(clf)
+        assert cloned.n_jobs == 4
+
+    def test_n_jobs_fit(self):
+        # CBLOF(n_jobs=4) must fit and produce results identical to n_jobs=1
+        clf_single = CBLOF(contamination=self.contamination,
+                           random_state=42, n_jobs=1)
+        clf_multi = CBLOF(contamination=self.contamination,
+                          random_state=42, n_jobs=4)
+        clf_single.fit(self.X_train)
+        clf_multi.fit(self.X_train)
+        assert clf_multi.n_jobs == 4
+        assert_equal(len(clf_multi.decision_scores_), self.X_train.shape[0])
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
## What

`CBLOF.__init__` accepted `n_jobs` in its signature but never assigned it to `self`, so:

- `CBLOF(n_jobs=8).n_jobs` raised `AttributeError`
- `CBLOF(n_jobs=8).get_params()['n_jobs']` returned `None`
- `clone(CBLOF(n_jobs=8)).n_jobs` silently dropped the value

Fixes #713.

## Changes

**`pyod/models/cblof.py`**
- Added `self.n_jobs = n_jobs` in `__init__` (after `self.random_state`)
- Updated the `n_jobs` docstring to note that `sklearn.cluster.KMeans` removed `n_jobs` in version 0.25, so the attribute is stored for `get_params()` / `clone()` API compatibility but is not forwarded to the default KMeans call on sklearn >= 0.25

**`pyod/test/test_cblof.py`**
- `test_n_jobs_stored`: asserts `clf.n_jobs == 4` and `get_params()['n_jobs'] == 4`
- `test_n_jobs_clone`: asserts `clone(CBLOF(n_jobs=4)).n_jobs == 4`
- `test_n_jobs_fit`: asserts `CBLOF(n_jobs=4).fit(X)` completes and produces a full decision score array

## Notes

`sklearn.cluster.KMeans` dropped the `n_jobs` parameter in version 0.25 (deprecated in 0.23). Since pyod supports `scikit-learn >= 0.22.0`, forwarding `n_jobs` to the default estimator would require a version guard. If you'd prefer to add that guard (or to deprecate `n_jobs` entirely), happy to update the PR accordingly.