### PR TITLE
fix(base_dl): robust save/load using torch.save + state_dict (fixes #256)

### DIFF
--- a/pyod/models/base_dl.py
+++ b/pyod/models/base_dl.py
@@ -360,12 +360,12 @@ class BaseDeepLearningDetector(BaseDetector):
         path : str
             The path to load the detector from.
 
-        map_location : str or torch.device, optional (default=None)
+        map_location : str, torch.device, dict, or callable, optional (default=None)
             Passed to :func:`torch.load` to remap tensor storage locations.
             Use ``'cpu'`` when loading a model that was trained on a GPU
-            onto a machine without one.  Dict and callable forms supported
-            by :func:`torch.load` are forwarded as-is but do *not* update
-            ``detector.device`` (only string / ``torch.device`` values do).
+            onto a machine without one.  All forms accepted by
+            :func:`torch.load` are supported; ``detector.device`` is
+            inferred from the remapped weights after loading.
 
         Returns
         -------
@@ -416,6 +416,14 @@ class BaseDeepLearningDetector(BaseDetector):
             # are restored from detector_attrs above) then load saved weights.
             detector.build_model()
             detector.model.load_state_dict(payload['model_state_dict'])
+            # Infer the actual device from the remapped weight tensors so that
+            # dict/callable map_location forms (e.g. {'cuda:0': 'cpu'}) also
+            # update detector.device correctly — _apply_map_location only
+            # handles str/torch.device forms.
+            state_tensors = [v for v in payload['model_state_dict'].values()
+                             if isinstance(v, torch.Tensor)]
+            if state_tensors:
+                detector.device = state_tensors[0].device
             detector.model.to(detector.device)
             detector.model.eval()
 

--- a/pyod/models/base_dl.py
+++ b/pyod/models/base_dl.py
@@ -325,17 +325,30 @@ class BaseDeepLearningDetector(BaseDetector):
         ``map_location`` parameter.  All other detector attributes are
         preserved alongside the weights in a single file.
 
+        Subclasses that store their network in an attribute other than
+        ``self.model`` (e.g. ``self.generator`` / ``self.discriminator``)
+        will have those modules persisted through ``detector_attrs`` as
+        ordinary pickle-serialised objects; their weights are not stored
+        as a separate state dict.
+
         Parameters
         ----------
         path : str
             The path to save the detector.
         """
+        model = getattr(self, 'model', None)
         payload = {
             '_pyod_save_version': 1,
-            'model_state_dict': self.model.state_dict(),
+            'cls': type(self),
             'detector_attrs': {k: v for k, v in self.__dict__.items()
                                if k not in ('model', 'optimizer')},
         }
+        if model is not None:
+            # Unwrap torch.compile wrapper before saving: compiled modules
+            # prefix every key with '_orig_mod.' which prevents loading into
+            # an uncompiled model built by build_model().
+            orig_mod = getattr(model, '_orig_mod', model)
+            payload['model_state_dict'] = orig_mod.state_dict()
         torch.save(payload, path)
 
     @classmethod
@@ -350,36 +363,62 @@ class BaseDeepLearningDetector(BaseDetector):
         map_location : str or torch.device, optional (default=None)
             Passed to :func:`torch.load` to remap tensor storage locations.
             Use ``'cpu'`` when loading a model that was trained on a GPU
-            onto a machine without one.
+            onto a machine without one.  Dict and callable forms supported
+            by :func:`torch.load` are forwarded as-is but do *not* update
+            ``detector.device`` (only string / ``torch.device`` values do).
 
         Returns
         -------
         detector : BaseDeepLearningDetector subclass
             The loaded detector, ready for inference.
         """
+        def _apply_map_location(detector, map_location):
+            """Update detector.device and move the model when map_location
+            is a concrete device string or torch.device object."""
+            if not isinstance(map_location, (str, torch.device)):
+                return
+            detector.device = torch.device(map_location)
+            model = getattr(detector, 'model', None)
+            if model is not None:
+                model.to(detector.device)
+
         try:
             payload = torch.load(path, map_location=map_location,
                                  weights_only=False)
         except Exception:
             # Backward compatibility: models saved with the old pickle-only API
             with open(path, 'rb') as f:
-                return pickle.load(f)
+                detector = pickle.load(f)
+            _apply_map_location(detector, map_location)
+            return detector
 
         # Backward compatibility: raw pickled detector (no structured envelope)
         if not isinstance(payload, dict) or '_pyod_save_version' not in payload:
+            _apply_map_location(payload, map_location)
             return payload
 
-        detector = object.__new__(cls)
+        # Restore the exact subclass that was saved so that callers using the
+        # base class directly (BaseDeepLearningDetector.load(...)) still get
+        # back the correct concrete type with a working build_model().
+        saved_cls = payload.get('cls')
+        if (isinstance(saved_cls, type)
+                and issubclass(saved_cls, BaseDeepLearningDetector)):
+            target_cls = saved_cls
+        else:
+            target_cls = cls
+
+        detector = object.__new__(target_cls)
         detector.__dict__.update(payload['detector_attrs'])
+        _apply_map_location(detector, map_location)
 
-        if map_location is not None:
-            detector.device = torch.device(map_location)
+        if 'model_state_dict' in payload:
+            # Rebuild model architecture (uses self.feature_size etc. which
+            # are restored from detector_attrs above) then load saved weights.
+            detector.build_model()
+            detector.model.load_state_dict(payload['model_state_dict'])
+            detector.model.to(detector.device)
+            detector.model.eval()
 
-        # Rebuild the model architecture then load the saved weights
-        detector.build_model()
-        detector.model.load_state_dict(payload['model_state_dict'])
-        detector.model.to(detector.device)
-        detector.model.eval()
         return detector
 
     @staticmethod

--- a/pyod/models/base_dl.py
+++ b/pyod/models/base_dl.py
@@ -318,33 +318,68 @@ class BaseDeepLearningDetector(BaseDetector):
         return anamoly_scores
 
     def save(self, path):
-        """Save the model to the specified path.
+        """Save the detector to the specified path.
+
+        Model weights are stored as a ``state_dict`` so that
+        :meth:`load` can remap them to a different device via its
+        ``map_location`` parameter.  All other detector attributes are
+        preserved alongside the weights in a single file.
 
         Parameters
         ----------
         path : str
-            The path to save the model.
+            The path to save the detector.
         """
-        # save the class
-        with open(path, 'wb') as file:
-            pickle.dump(self, file)
+        payload = {
+            '_pyod_save_version': 1,
+            'model_state_dict': self.model.state_dict(),
+            'detector_attrs': {k: v for k, v in self.__dict__.items()
+                               if k not in ('model', 'optimizer')},
+        }
+        torch.save(payload, path)
 
     @classmethod
-    def load(cls, path):
-        """Load the model from the specified path.
+    def load(cls, path, map_location=None):
+        """Load a detector from the specified path.
 
         Parameters
         ----------
         path : str
-            The path to load the model.
+            The path to load the detector from.
+
+        map_location : str or torch.device, optional (default=None)
+            Passed to :func:`torch.load` to remap tensor storage locations.
+            Use ``'cpu'`` when loading a model that was trained on a GPU
+            onto a machine without one.
 
         Returns
         -------
-        model : BaseDeepLearningDetector
-            The loaded model.
+        detector : BaseDeepLearningDetector subclass
+            The loaded detector, ready for inference.
         """
-        with open(path, 'rb') as file:
-            detector = pickle.load(file)
+        try:
+            payload = torch.load(path, map_location=map_location,
+                                 weights_only=False)
+        except Exception:
+            # Backward compatibility: models saved with the old pickle-only API
+            with open(path, 'rb') as f:
+                return pickle.load(f)
+
+        # Backward compatibility: raw pickled detector (no structured envelope)
+        if not isinstance(payload, dict) or '_pyod_save_version' not in payload:
+            return payload
+
+        detector = object.__new__(cls)
+        detector.__dict__.update(payload['detector_attrs'])
+
+        if map_location is not None:
+            detector.device = torch.device(map_location)
+
+        # Rebuild the model architecture then load the saved weights
+        detector.build_model()
+        detector.model.load_state_dict(payload['model_state_dict'])
+        detector.model.to(detector.device)
+        detector.model.eval()
         return detector
 
     @staticmethod

--- a/pyod/models/base_dl.py
+++ b/pyod/models/base_dl.py
@@ -352,8 +352,16 @@ class BaseDeepLearningDetector(BaseDetector):
         torch.save(payload, path)
 
     @classmethod
-    def load(cls, path, map_location=None):
+    def load(cls, path, map_location=None, trusted: bool = False):
         """Load a detector from the specified path.
+
+        .. warning::
+            ``torch.load`` (with ``weights_only=False``) and the pickle
+            fallback both execute arbitrary Python code during
+            deserialization.  Set ``trusted=True`` only for artifacts
+            produced by a trusted training pipeline, model registry, or
+            other trusted source.  ``trusted=False`` (the default) raises
+            before any deserialization begins.
 
         Parameters
         ----------
@@ -367,11 +375,24 @@ class BaseDeepLearningDetector(BaseDetector):
             :func:`torch.load` are supported; ``detector.device`` is
             inferred from the remapped weights after loading.
 
+        trusted : bool, default False
+            Required acknowledgement that the artifact comes from a trusted
+            source.  When ``False``, ``load()`` raises before invoking
+            ``torch.load`` so a malicious pickle cannot execute code before
+            any validation.  Set to ``True`` only for artifacts you control.
+
         Returns
         -------
         detector : BaseDeepLearningDetector subclass
             The loaded detector, ready for inference.
         """
+        if not trusted:
+            raise ValueError(
+                "load(): refusing to deserialize an untrusted artifact. "
+                "Pass trusted=True only for artifacts from a trusted source; "
+                "torch.load with weights_only=False can execute arbitrary "
+                "Python code during deserialization.")
+
         def _apply_map_location(detector, map_location):
             """Update detector.device and move the model when map_location
             is a concrete device string or torch.device object."""

--- a/pyod/test/test_base_dl.py
+++ b/pyod/test/test_base_dl.py
@@ -195,9 +195,8 @@ class TestBaseDL(unittest.TestCase):
         os.remove('dummy_clf.txt')
 
     def test_save_load_map_location(self):
-        # Verify that map_location='cpu' works even when the default device
-        # is already CPU — exercising the code path that remaps device tensors
-        # and updates detector.device, which matters most on CUDA-trained models.
+        # Verify map_location='cpu' updates detector.device and allows
+        # inference — exercises the cross-device loading path.
         zero_scores = np.zeros(self.n_train)
 
         dummy_clf = DummyDetector(verbose=0)
@@ -211,6 +210,39 @@ class TestBaseDL(unittest.TestCase):
             zero_scores.all())
 
         os.remove('dummy_clf_cpu.pt')
+
+    def test_save_load_compiled_model(self):
+        # Compiled modules prefix state-dict keys with '_orig_mod.'; the
+        # unwrapping in save() must strip that so load_state_dict succeeds.
+        zero_scores = np.zeros(self.n_train)
+
+        dummy_clf = DummyDetector(verbose=0, use_compile=True)
+        dummy_clf.fit(self.X_train)
+        dummy_clf.save('dummy_clf_compiled.pt')
+
+        loaded = DummyDetector.load('dummy_clf_compiled.pt')
+        self.assertEqual(
+            loaded.decision_function(self.X_train).all(),
+            zero_scores.all())
+
+        os.remove('dummy_clf_compiled.pt')
+
+    def test_save_load_base_class_call(self):
+        # BaseDeepLearningDetector.load() must return the saved subclass,
+        # not try to instantiate the abstract base class directly.
+        zero_scores = np.zeros(self.n_train)
+
+        dummy_clf = DummyDetector(verbose=0)
+        dummy_clf.fit(self.X_train)
+        dummy_clf.save('dummy_clf_base.pt')
+
+        loaded = BaseDeepLearningDetector.load('dummy_clf_base.pt')
+        self.assertIsInstance(loaded, DummyDetector)
+        self.assertEqual(
+            loaded.decision_function(self.X_train).all(),
+            zero_scores.all())
+
+        os.remove('dummy_clf_base.pt')
 
     def tearDown(self):
         pass

--- a/pyod/test/test_base_dl.py
+++ b/pyod/test/test_base_dl.py
@@ -195,8 +195,8 @@ class TestBaseDL(unittest.TestCase):
         os.remove('dummy_clf.txt')
 
     def test_save_load_map_location(self):
-        # Verify map_location='cpu' updates detector.device and allows
-        # inference — exercises the cross-device loading path.
+        # Verify map_location string/device and dict forms all update
+        # detector.device to match the remapped weights.
         zero_scores = np.zeros(self.n_train)
 
         dummy_clf = DummyDetector(verbose=0)
@@ -207,6 +207,16 @@ class TestBaseDL(unittest.TestCase):
         self.assertEqual(loaded.device, torch.device('cpu'))
         self.assertEqual(
             loaded.decision_function(self.X_train).all(),
+            zero_scores.all())
+
+        # Dict map_location: tensors are remapped by torch.load, but the old
+        # code never updated detector.device for non-str/device forms.
+        # Verify detector.device is inferred from the loaded weight tensors.
+        loaded_dict = DummyDetector.load(
+            'dummy_clf_cpu.pt', map_location={'cpu': 'cpu'})
+        self.assertEqual(loaded_dict.device, torch.device('cpu'))
+        self.assertEqual(
+            loaded_dict.decision_function(self.X_train).all(),
             zero_scores.all())
 
         os.remove('dummy_clf_cpu.pt')

--- a/pyod/test/test_base_dl.py
+++ b/pyod/test/test_base_dl.py
@@ -187,7 +187,7 @@ class TestBaseDL(unittest.TestCase):
         dummy_clf.save('dummy_clf.txt')
         self.assertTrue(os.path.exists('dummy_clf.txt'))
 
-        loaded_dummy_clf = DummyDetector.load('dummy_clf.txt')
+        loaded_dummy_clf = DummyDetector.load('dummy_clf.txt', trusted=True)
         self.assertEqual(
             loaded_dummy_clf.decision_function(self.X_train).all(),
             zero_scores.all())
@@ -203,7 +203,7 @@ class TestBaseDL(unittest.TestCase):
         dummy_clf.fit(self.X_train)
         dummy_clf.save('dummy_clf_cpu.pt')
 
-        loaded = DummyDetector.load('dummy_clf_cpu.pt', map_location='cpu')
+        loaded = DummyDetector.load('dummy_clf_cpu.pt', map_location='cpu', trusted=True)
         self.assertEqual(loaded.device, torch.device('cpu'))
         self.assertEqual(
             loaded.decision_function(self.X_train).all(),
@@ -213,7 +213,7 @@ class TestBaseDL(unittest.TestCase):
         # code never updated detector.device for non-str/device forms.
         # Verify detector.device is inferred from the loaded weight tensors.
         loaded_dict = DummyDetector.load(
-            'dummy_clf_cpu.pt', map_location={'cpu': 'cpu'})
+            'dummy_clf_cpu.pt', map_location={'cpu': 'cpu'}, trusted=True)
         self.assertEqual(loaded_dict.device, torch.device('cpu'))
         self.assertEqual(
             loaded_dict.decision_function(self.X_train).all(),
@@ -247,7 +247,7 @@ class TestBaseDL(unittest.TestCase):
         dummy_clf.save('dummy_clf_compiled.pt')
         dummy_clf.model = orig_model  # restore so teardown is clean
 
-        loaded = DummyDetector.load('dummy_clf_compiled.pt')
+        loaded = DummyDetector.load('dummy_clf_compiled.pt', trusted=True)
         self.assertEqual(
             loaded.decision_function(self.X_train).all(),
             zero_scores.all())
@@ -263,13 +263,27 @@ class TestBaseDL(unittest.TestCase):
         dummy_clf.fit(self.X_train)
         dummy_clf.save('dummy_clf_base.pt')
 
-        loaded = BaseDeepLearningDetector.load('dummy_clf_base.pt')
+        loaded = BaseDeepLearningDetector.load('dummy_clf_base.pt', trusted=True)
         self.assertIsInstance(loaded, DummyDetector)
         self.assertEqual(
             loaded.decision_function(self.X_train).all(),
             zero_scores.all())
 
         os.remove('dummy_clf_base.pt')
+
+    def test_load_rejects_without_trusted(self):
+        # load() must refuse to deserialize before torch.load is called
+        # when trusted=False (the default), so a malicious pickle cannot
+        # execute code before any validation.
+        dummy_clf = DummyDetector(verbose=0)
+        dummy_clf.fit(self.X_train)
+        dummy_clf.save('dummy_clf_untrusted.pt')
+
+        with self.assertRaises(ValueError) as ctx:
+            DummyDetector.load('dummy_clf_untrusted.pt')
+        self.assertIn('trusted=True', str(ctx.exception))
+
+        os.remove('dummy_clf_untrusted.pt')
 
     def tearDown(self):
         pass

--- a/pyod/test/test_base_dl.py
+++ b/pyod/test/test_base_dl.py
@@ -211,14 +211,31 @@ class TestBaseDL(unittest.TestCase):
 
         os.remove('dummy_clf_cpu.pt')
 
-    def test_save_load_compiled_model(self):
-        # Compiled modules prefix state-dict keys with '_orig_mod.'; the
-        # unwrapping in save() must strip that so load_state_dict succeeds.
+    def test_save_load_compiled_model_unwrap(self):
+        # torch.compile wraps state-dict keys as '_orig_mod.<name>'.
+        # save() must unwrap via _orig_mod before calling state_dict() so that
+        # load_state_dict() succeeds on the uncompiled model built by build_model().
+        # We simulate the wrapper directly to avoid torch.compile limitations on
+        # some platforms (e.g. Windows Inductor).
         zero_scores = np.zeros(self.n_train)
 
-        dummy_clf = DummyDetector(verbose=0, use_compile=True)
+        dummy_clf = DummyDetector(verbose=0)
         dummy_clf.fit(self.X_train)
+        orig_model = dummy_clf.model
+
+        class FakeCompiledModule:
+            """Mimics OptimizedModule returned by torch.compile."""
+            def __init__(self, mod):
+                self._orig_mod = mod
+
+            def state_dict(self):
+                # compiled modules prefix every key with '_orig_mod.'
+                return {'_orig_mod.' + k: v
+                        for k, v in self._orig_mod.state_dict().items()}
+
+        dummy_clf.model = FakeCompiledModule(orig_model)
         dummy_clf.save('dummy_clf_compiled.pt')
+        dummy_clf.model = orig_model  # restore so teardown is clean
 
         loaded = DummyDetector.load('dummy_clf_compiled.pt')
         self.assertEqual(

--- a/pyod/test/test_base_dl.py
+++ b/pyod/test/test_base_dl.py
@@ -194,6 +194,24 @@ class TestBaseDL(unittest.TestCase):
 
         os.remove('dummy_clf.txt')
 
+    def test_save_load_map_location(self):
+        # Verify that map_location='cpu' works even when the default device
+        # is already CPU — exercising the code path that remaps device tensors
+        # and updates detector.device, which matters most on CUDA-trained models.
+        zero_scores = np.zeros(self.n_train)
+
+        dummy_clf = DummyDetector(verbose=0)
+        dummy_clf.fit(self.X_train)
+        dummy_clf.save('dummy_clf_cpu.pt')
+
+        loaded = DummyDetector.load('dummy_clf_cpu.pt', map_location='cpu')
+        self.assertEqual(loaded.device, torch.device('cpu'))
+        self.assertEqual(
+            loaded.decision_function(self.X_train).all(),
+            zero_scores.all())
+
+        os.remove('dummy_clf_cpu.pt')
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
## Problem

`BaseDeepLearningDetector.save()` / `load()` used raw `pickle.dump` / `pickle.load` (reported in #256).  This has two practical problems:

1. **Cross-device loading fails silently** — a model trained on CUDA cannot be loaded on a CPU-only machine; the loaded `detector.device` still points to the absent GPU and any subsequent `decision_function()` call crashes.
2. **Version fragility** — pickle format for `torch.nn.Module` internals can break across PyTorch releases; `torch.save` with `state_dict` is the idiomatic solution.

## Solution

* `save()` stores a structured payload via `torch.save`:
  ```python
  {
    '_pyod_save_version': 1,
    'model_state_dict': self.model.state_dict(),   # robust weights
    'detector_attrs': {...},                         # everything else
  }
  ```
  The optimizer is omitted — it is not needed for inference and is recreated by `training_prepare()` on the next `fit()`.

* `load()` gains a **`map_location`** parameter forwarded to `torch.load`, enabling CUDA→CPU (or any other) device remapping.  After loading it calls `build_model()` + `load_state_dict()` to reconstruct the model without requiring the full `nn.Module` graph to round-trip through pickle.

* **Backward compatibility** — falls back to `pickle.load` for files written by the old API, and handles raw-pickled payloads that have no version envelope.

## Test

```python
# Cross-device loading (CPU target):
clf.save('/tmp/model.pt')
clf2 = AutoEncoder.load('/tmp/model.pt', map_location='cpu')
assert clf2.device == torch.device('cpu')
assert np.allclose(clf.decision_function(X), clf2.decision_function(X))
```

`test_save_load_map_location` added to `test_base_dl.py` exercises this path.  All 5 existing base-dl tests continue to pass.