### PR TITLE
fix(rod): eliminate RuntimeWarning when a data point coincides with the geometric median (closes #523)

### DIFF
--- a/pyod/models/rod.py
+++ b/pyod/models/rod.py
@@ -199,8 +199,16 @@ def rod_3D(x, gm=None, median=None, scaler1=None, scaler2=None):
     _x = x - gm
     # calculate the scaled angles between the geometric median and each data point vector
     v_norm = np.linalg.norm(_x, axis=1)
+    # Avoid divide-by-zero when a point coincides with the geometric median
+    # (v_norm == 0) or the median is at the origin (norm_ == 0).
+    # In both cases the angle is undefined; treat it as π/2 so the rotation
+    # cost (v_norm³ · cos · sin²) collapses to 0 and does not contaminate MAD.
+    safe_denom = v_norm * norm_
+    cos_vals = np.where(safe_denom > 0,
+                        np.dot(_x, gm) / np.where(safe_denom > 0, safe_denom, 1.0),
+                        0.0)
     gammas, scaler1, scaler2 = scale_angles(
-        np.arccos(np.clip(np.dot(_x, gm) / (v_norm * norm_), -1, 1)),
+        np.arccos(np.clip(cos_vals, -1, 1)),
         scaler1=scaler1, scaler2=scaler2)
     # apply the ROD main equation to find the rotation costs
     costs = np.power(v_norm, 3) * np.cos(gammas) * np.square(np.sin(gammas))

--- a/pyod/test/test_rod.py
+++ b/pyod/test/test_rod.py
@@ -161,11 +161,15 @@ class TestROD(unittest.TestCase):
         assert_equal(0.5, sigmoid(np.array([0.0])))
 
     def test_process_sub(self):
-        subspace = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]])
-        assert_equal([0.5, 0.5, 0.5],
-                     process_sub(subspace, self.gm, self.median,
-                                 self.angles_scalers1, self.angles_scalers2)[
-                         0])
+        subspace = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=float)
+        result = process_sub(subspace, self.gm, self.median,
+                             self.angles_scalers1, self.angles_scalers2)[0]
+        # Middle point coincides with the geometric median (v_norm=0).
+        # Before the issue-#523 fix, the NaN it produced infected the MAD
+        # computation and collapsed all three scores to sigmoid(0)=0.5.
+        # The corrected output treats the zero-norm point as angle=pi/2
+        # (rotation cost=0) and computes the outer points' scores properly.
+        assert_allclose(result, [1.0, 0.5, 0.6625], atol=1e-3)
 
     def test_parallel_vs_non_parallel(self):
         assert_equal(rod_nD(self.X_train, False, self.gm, self.data_scaler,
@@ -176,6 +180,31 @@ class TestROD(unittest.TestCase):
     def test_mad(self):
         gm, _ = mad(np.array([1, 2, 3]))
         assert_equal([0.6745, 0.0, 0.6745], gm)
+
+    def test_rod_3D_no_nan_when_point_at_geometric_median(self):
+        # Regression test for issue #523: rod_3D emitted
+        # "RuntimeWarning: invalid value encountered in divide" when a data
+        # point coincided exactly with the geometric median (v_norm = 0).
+        # Symmetric data centred on a non-zero point has its geometric median
+        # at that centre, so the first row triggers v_norm = 0 while
+        # norm_ = ||gm|| > 0 (the two conditions in the original bug).
+        import warnings
+        center = np.array([2.0, 3.0, 1.0])
+        X = np.vstack([
+            center,                  # coincides with geometric median
+            center + [1, 0, 0],
+            center + [-1, 0, 0],
+            center + [0, 1, 0],
+            center + [0, -1, 0],
+            center + [0, 0, 1],
+            center + [0, 0, -1],
+        ])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            scores, _, _, _, _ = rod_3D(X)
+        self.assertFalse(np.any(np.isnan(scores)),
+                         "rod_3D must not produce NaN when a data point "
+                         "coincides with the geometric median (issue #523)")
 
     def test_model_clone(self):
         clone_clf = clone(self.clf)


### PR DESCRIPTION
## What

`rod_3D` in `pyod/models/rod.py` divides by `v_norm * norm_` to compute the cosine of the angle between each centred data point and the geometric median. When any data point coincides with the geometric median, `_x[i] = 0`, so `v_norm[i] = 0`, making the denominator zero. NumPy then emits:

```
RuntimeWarning: invalid value encountered in divide
  gammas, scaler1, scaler2 = scale_angles(np.arccos(np.clip(np.dot(_x, gm) / (v_norm * norm_), -1, 1)),
```

The resulting NaN angle propagates through `scale_angles`, produces NaN rotation costs, and (via the `0/0` path in `mad`) collapses the entire subspace's scores to `sigmoid(0) = 0.5` after `nan_to_num`. This silently degrades anomaly detection quality for any dataset with duplicate points that happen to equal the geometric median in a 3D subspace.

Fixes #523.

## Why this matters

This is reported against the "optdigits" dataset (from ADBench), which is a standard anomaly-detection benchmark. Any dataset with repeated rows or discrete features can trigger the same path.

## Fix

Replace the bare division with a masked safe-denominator:

```python
safe_denom = v_norm * norm_
cos_vals = np.where(safe_denom > 0,
                    np.dot(_x, gm) / np.where(safe_denom > 0, safe_denom, 1.0),
                    0.0)
```

Points where `safe_denom == 0` (either `v_norm = 0` or `norm_ = 0`) are assigned `cos = 0` → angle = π/2. This is geometrically sound: a point with zero displacement from the geometric median has an undefined angle, and treating it as orthogonal makes the rotation cost `v_norm³ · cos(π/2) · sin²(π/2) = 0`.

## Tests

- **New** `test_rod_3D_no_nan_when_point_at_geometric_median`: constructs a symmetric dataset centred on a non-zero point (so `norm_ > 0`), whose centre row triggers `v_norm = 0`. Asserts no `RuntimeWarning` is raised and no NaN appears in the scores.
- **Updated** `test_process_sub`: the previous assertion `[0.5, 0.5, 0.5]` reflected the NaN-corrupted behaviour. The corrected expected values `[1.0, 0.5, 0.6625]` are produced once the divide-by-zero is fixed. A comment explains why the values changed.