### PR TITLE
FIX: Prevent false-positive Claude Code detection in pyod info (#715)

### DIFF
--- a/pyod/cli.py
+++ b/pyod/cli.py
@@ -18,6 +18,7 @@ backward-compat alias. It shares the same ``_run_install`` helper as
 from __future__ import annotations
 
 import argparse
+import shutil
 import importlib.util
 import sys
 from collections import Counter
@@ -101,7 +102,7 @@ def _cmd_info(args: argparse.Namespace) -> int:
     user_installed = user_skill_path.is_file()
     project_installed = project_skill_path.is_file()
     agents_detected: list[str] = []
-    if claude_dir.is_dir():
+    if shutil.which("claude") is not None or (Path.home() / ".claude.json").exists():
         agents_detected.append("Claude Code")
     if codex_dir.is_dir():
         agents_detected.append("Codex")

--- a/pyod/test/test_cli.py
+++ b/pyod/test/test_cli.py
@@ -168,12 +168,13 @@ def test_pyod_info_codex_detected_no_skill(tmp_path):
     assert "no agent stacks detected" not in result.stdout
 
 
-def test_pyod_info_codex_and_claude_both_detected(tmp_path):
+def test_pyod_info_codex_and_claude_both_detected(tmp_path,monkeypatch):
     """Both ~/.claude/ and ~/.codex/ present, neither skill installed.
 
     Output must list both agents and show both install commands so the
     user knows which option fits their workflow.
     """
+    monkeypatch.setattr("shutil.which", lambda cmd: None)
     fake_home = tmp_path / "fake_home"
     fake_home.mkdir(parents=True, exist_ok=True)
     (fake_home / ".claude.json").touch()

--- a/pyod/test/test_cli.py
+++ b/pyod/test/test_cli.py
@@ -175,7 +175,8 @@ def test_pyod_info_codex_and_claude_both_detected(tmp_path):
     user knows which option fits their workflow.
     """
     fake_home = tmp_path / "fake_home"
-    (fake_home / ".claude").mkdir(parents=True)
+    fake_home.mkdir(parents=True, exist_ok=True)
+    (fake_home / ".claude.json").touch()
     (fake_home / ".codex").mkdir(parents=True)
 
     work = tmp_path / "work"


### PR DESCRIPTION
Fixes #715.

# Issue
PyOD creates `~/.claude/skills/` during skill installation, creating `~/.claude/` as a side effect. Checking only for the `~/.claude` directory caused `pyod info` to report a false positive for Claude Code being installed.

# Solution
- Updated `pyod/cli.py` to verify Claude Code presence via `shutil.which("claude")` or `~/.claude.json`.
- Updated test environment setup in `pyod/test/test_cli.py`.

# Testing
Ran `pytest pyod/test/test_cli.py` (15/15 passed).
