### PR TITLE
Add SmallN detector: Mahalanobis distance with Ledoit-Wolf shrinkage …

### DIFF
--- a/docs/pyod.models.tabular.rst
+++ b/docs/pyod.models.tabular.rst
@@ -371,6 +371,15 @@ pyod.models.sampling module
     :show-inheritance:
 
 
+pyod.models.small\_n module
+----------------------------
+
+.. automodule:: pyod.models.small_n
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+    
 pyod.models.so\_gaal module
 ---------------------------
 

--- a/examples/small_n_example.py
+++ b/examples/small_n_example.py
@@ -1,0 +1,16 @@
+"""Example of using SmallN detector for scoring outliers
+against a small reference set (n=3-10).
+"""
+
+import numpy as np
+
+from pyod.models.small_n import SmallN
+
+X_train = np.array([[1.0, 2.1], [1.1, 1.9], [0.9, 2.0]])
+X_test = np.array([[1.0, 2.0], [8.0, 8.0]])
+
+clf = SmallN(contamination=0.3)
+clf.fit(X_train)
+
+print("Decision scores on training data:", clf.decision_scores_)
+print("Predicted labels on test data:", clf.predict(X_test))

--- a/pyod/models/small_n.py
+++ b/pyod/models/small_n.py
@@ -1,9 +1,9 @@
 """Outlier detection for small reference sets using Mahalanobis distance
 with Ledoit-Wolf shrinkage covariance.
 
-Standard covariance-based detectors assume enough samples to
-estimate covariance robustly, usually well more than the
-number of features. Ledoit-Wolf shrinkage instead adapts its
+Standard covariance-based detectors, including PyOD's own MCD, assume
+enough samples to estimate covariance robustly, usually well more than
+the number of features. Ledoit-Wolf shrinkage instead adapts its
 regularisation to the ratio of sample count to dimensionality, staying
 stable down to n=3, by pulling the covariance estimate toward a scaled
 identity matrix rather than requiring a full-rank sample covariance.
@@ -14,6 +14,8 @@ from sklearn.covariance import LedoitWolf
 from sklearn.utils.validation import check_array, check_is_fitted
 
 from .base import BaseDetector
+
+_RIDGE = 1e-6
 
 
 class SmallN(BaseDetector):
@@ -26,22 +28,34 @@ class SmallN(BaseDetector):
         X = check_array(X)
         self._set_n_classes(y)
 
+        self.n_features_ = X.shape[1]
         self.centroid_ = np.mean(X, axis=0)
         n = X.shape[0]
         if n >= 2:
             lw = LedoitWolf()
             lw.fit(X)
-            self.inv_cov_ = np.linalg.pinv(lw.covariance_)
+            cov = lw.covariance_
         else:
-            self.inv_cov_ = np.eye(X.shape[1])
+            cov = np.eye(self.n_features_)
+
+        # A degenerate (all-zero) covariance happens when every reference
+        # row is identical, its pseudo-inverse is also zero, which would
+        # silently score every future point as 0 regardless of how far
+        # it is from the centroid. A small ridge keeps the metric usable.
+        cov = cov + _RIDGE * np.eye(self.n_features_)
+        self.inv_cov_ = np.linalg.pinv(cov)
 
         self.decision_scores_ = self._mahalanobis_batch(X)
         self._process_decision_scores()
         return self
 
     def decision_function(self, X):
-        check_is_fitted(self, ['centroid_', 'inv_cov_'])
+        check_is_fitted(self, ['centroid_', 'inv_cov_', 'n_features_'])
         X = check_array(X)
+        if X.shape[1] != self.n_features_:
+            raise ValueError(
+                'X has {} features, but SmallN was fitted with {} '
+                'features.'.format(X.shape[1], self.n_features_))
         return self._mahalanobis_batch(X)
 
     def _mahalanobis_batch(self, X):
@@ -49,3 +63,31 @@ class SmallN(BaseDetector):
         mahalanobis_sq = np.einsum(
             'ij,jk,ik->i', diffs, self.inv_cov_, diffs)
         return np.sqrt(np.maximum(mahalanobis_sq, 0))
+
+    def compute_rejection_stats(self, T=32, delta=0.1, c_fp=1, c_fn=1,
+                                c_r=-1, verbose=False):
+        """Overrides BaseDetector.compute_rejection_stats to fail with a
+        clear message instead of an opaque scipy error.
+
+        The inherited implementation computes
+        int(n * contamination) - 1, which goes negative for small n and
+        typical contamination values (e.g. n=3, contamination=0.1 gives
+        -1), and then hands that negative value to a binomial CDF root
+        solver with no valid bracket, raising an unrelated-looking
+        ValueError from inside scipy. This detector is specifically for
+        small n, so that combination is expected to come up, and it
+        deserves a message that actually explains what to change.
+        """
+        check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
+        n = len(self.decision_scores_)
+        if int(n * self.contamination) - 1 < 0:
+            raise ValueError(
+                'compute_rejection_stats is not supported for this '
+                'combination of n={} and contamination={}, since '
+                'int(n * contamination) - 1 is negative. Use a larger '
+                'reference set or a higher contamination value if '
+                'rejection statistics are needed.'.format(
+                    n, self.contamination))
+        return super(SmallN, self).compute_rejection_stats(
+            T=T, delta=delta, c_fp=c_fp, c_fn=c_fn, c_r=c_r,
+            verbose=verbose)

--- a/pyod/models/small_n.py
+++ b/pyod/models/small_n.py
@@ -38,10 +38,6 @@ class SmallN(BaseDetector):
         else:
             cov = np.eye(self.n_features_)
 
-        # A degenerate (all-zero) covariance happens when every reference
-        # row is identical, its pseudo-inverse is also zero, which would
-        # silently score every future point as 0 regardless of how far
-        # it is from the centroid. A small ridge keeps the metric usable.
         cov = cov + _RIDGE * np.eye(self.n_features_)
         self.inv_cov_ = np.linalg.pinv(cov)
 
@@ -64,19 +60,23 @@ class SmallN(BaseDetector):
             'ij,jk,ik->i', diffs, self.inv_cov_, diffs)
         return np.sqrt(np.maximum(mahalanobis_sq, 0))
 
+    def predict_proba(self, X, method='linear', return_confidence=False):
+        """
+        Overrides BaseDetector.predict_proba to guard the 'unify'
+        method against zero training-score variance.
+        """
+        check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
+        if method == 'unify' and self._sigma == 0:
+            return super(SmallN, self).predict_proba(
+                X, method='linear', return_confidence=return_confidence)
+        return super(SmallN, self).predict_proba(
+            X, method=method, return_confidence=return_confidence)
+
     def compute_rejection_stats(self, T=32, delta=0.1, c_fp=1, c_fn=1,
                                 c_r=-1, verbose=False):
-        """Overrides BaseDetector.compute_rejection_stats to fail with a
+        """
+        Overrides BaseDetector.compute_rejection_stats to fail with a
         clear message instead of an opaque scipy error.
-
-        The inherited implementation computes
-        int(n * contamination) - 1, which goes negative for small n and
-        typical contamination values (e.g. n=3, contamination=0.1 gives
-        -1), and then hands that negative value to a binomial CDF root
-        solver with no valid bracket, raising an unrelated-looking
-        ValueError from inside scipy. This detector is specifically for
-        small n, so that combination is expected to come up, and it
-        deserves a message that actually explains what to change.
         """
         check_is_fitted(self, ['decision_scores_', 'threshold_', 'labels_'])
         n = len(self.decision_scores_)

--- a/pyod/models/small_n.py
+++ b/pyod/models/small_n.py
@@ -1,0 +1,51 @@
+"""Outlier detection for small reference sets using Mahalanobis distance
+with Ledoit-Wolf shrinkage covariance.
+
+Standard covariance-based detectors assume enough samples to
+estimate covariance robustly, usually well more than the
+number of features. Ledoit-Wolf shrinkage instead adapts its
+regularisation to the ratio of sample count to dimensionality, staying
+stable down to n=3, by pulling the covariance estimate toward a scaled
+identity matrix rather than requiring a full-rank sample covariance.
+"""
+
+import numpy as np
+from sklearn.covariance import LedoitWolf
+from sklearn.utils.validation import check_array, check_is_fitted
+
+from .base import BaseDetector
+
+
+class SmallN(BaseDetector):
+    """Mahalanobis distance outlier detector for small reference sets."""
+
+    def __init__(self, contamination=0.1):
+        super(SmallN, self).__init__(contamination=contamination)
+
+    def fit(self, X, y=None):
+        X = check_array(X)
+        self._set_n_classes(y)
+
+        self.centroid_ = np.mean(X, axis=0)
+        n = X.shape[0]
+        if n >= 2:
+            lw = LedoitWolf()
+            lw.fit(X)
+            self.inv_cov_ = np.linalg.pinv(lw.covariance_)
+        else:
+            self.inv_cov_ = np.eye(X.shape[1])
+
+        self.decision_scores_ = self._mahalanobis_batch(X)
+        self._process_decision_scores()
+        return self
+
+    def decision_function(self, X):
+        check_is_fitted(self, ['centroid_', 'inv_cov_'])
+        X = check_array(X)
+        return self._mahalanobis_batch(X)
+
+    def _mahalanobis_batch(self, X):
+        diffs = X - self.centroid_
+        mahalanobis_sq = np.einsum(
+            'ij,jk,ik->i', diffs, self.inv_cov_, diffs)
+        return np.sqrt(np.maximum(mahalanobis_sq, 0))

--- a/pyod/skills/od_expert/SKILL.md
+++ b/pyod/skills/od_expert/SKILL.md
@@ -19,7 +19,7 @@ Fire this skill when:
 
 ## What you have access to
 
-PyOD ships <!-- KB-snapshot count -->61<!-- /KB-snapshot --> detectors across six modalities (43 tabular, 7 time series, 8 graph, 2 text, 2 image, 1 multimodal, 3 audio). Use the `ADEngine` session API to drive the full workflow:
+PyOD ships <!-- KB-snapshot count -->62<!-- /KB-snapshot --> detectors across six modalities (44 tabular, 7 time series, 8 graph, 2 text, 2 image, 1 multimodal, 3 audio). Use the `ADEngine` session API to drive the full workflow:
 
 ```python
 from pyod.utils.ad_engine import ADEngine

--- a/pyod/skills/od_expert/references/tabular.md
+++ b/pyod/skills/od_expert/references/tabular.md
@@ -1,6 +1,6 @@
 # Tabular anomaly detection reference
 
-PyOD's largest modality (43 of 61 buildable detectors). The agent loads this file when the master decision tree (in SKILL.md) routes to tabular.
+PyOD's largest modality (44 of 62 buildable detectors). The agent loads this file when the master decision tree (in SKILL.md) routes to tabular.
 
 ## Decision table by data shape (expert heuristics)
 
@@ -60,6 +60,7 @@ These are rules of thumb for reasoning about which detectors a non-expert would 
 - **SO_GAAL** (Single-Objective Generative Adversarial Active Learning) — complexity: time O(n * d * h * epochs), space O(d * h); best for: Exploratory anomaly detection with GAN-generated reference outliers; avoid when: Stable and fast results are required, or dataset is small; requires: pyod[torch]; paper: Liu et al., 2019
 - **SUOD** (Scalable Unsupervised Outlier Detection) — complexity: time varies (depends on base estimators), space varies; best for: Large-scale datasets where running multiple detectors is desired but time is limited; avoid when: Exact results from a single well-chosen detector are preferred; requires: pyod[suod]; paper: Zhao et al., MLSys 2021
 - **Sampling** (Rapid Distance-Based Outlier Detection via Sampling) — complexity: time O(n * s * d) where s is subset size, space O(n * d); best for: Large-scale datasets requiring fast distance-based outlier detection; avoid when: Precise and deterministic results are required or dataset is small enough for exact methods; paper: Sugiyama and Borgwardt, 2013
+- **SmallN** (Small-N Mahalanobis Distance (Ledoit-Wolf Shrinkage)) — complexity: time O(n * d^2), space O(d^2); best for: Small trusted reference sets, calibration runs, per-unit baselines, or pilot batches with only a handful of known-good observations; avoid when: Large reference sets are available, standard MCD or covariance-based detectors are more appropriate; paper: Ledoit and Wolf, 2004
 - **VAE** (Variational AutoEncoder) — complexity: time O(n * d * h * epochs), space O(d * h); best for: Datasets where probabilistic reconstruction scoring and smooth latent spaces are beneficial; avoid when: Simpler autoencoder or non-deep methods work well, or dataset is very small; requires: pyod[torch]; paper: Kingma and Welling, 2014
 - **XGBOD** (Extreme Gradient Boosting Outlier Detection) — complexity: time O(n * d * n_estimators * log(n)), space O(n * d); best for: Semi-supervised settings where some labeled anomalies are available; avoid when: No labeled data is available or a purely unsupervised approach is needed; requires: pyod[xgboost]; paper: Zhao and Hryniewicki, IJCNN 2018
 <!-- END KB-DERIVED: tabular-detector-list -->

--- a/pyod/test/test_small_n.py
+++ b/pyod/test/test_small_n.py
@@ -1,4 +1,5 @@
-"""Tests for pyod.models.small_n.SmallN.
+"""Tests for pyod.models.small_n.SmallN, matching the structure of
+pyod/test/test_mcd.py.
 """
 
 import unittest
@@ -32,6 +33,21 @@ class TestSmallN(unittest.TestCase):
         labels = self.clf.predict(self.X_test)
         assert_equal(len(labels), len(self.X_test))
         assert set(labels.tolist()).issubset({0, 1})
+
+    def test_wrong_feature_count_raises(self):
+        with self.assertRaises(ValueError):
+            self.clf.decision_function(np.array([[1.0], [2.0]]))
+
+    def test_degenerate_reference_set_still_flags_outliers(self):
+        X_degenerate = np.array([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]])
+        clf = SmallN(contamination=0.3)
+        clf.fit(X_degenerate)
+        score = clf.decision_function(np.array([[100.0, 100.0]]))
+        assert score[0] > 0
+
+    def test_rejection_stats_raises_clear_error_for_small_n(self):
+        with self.assertRaises(ValueError):
+            self.clf.compute_rejection_stats()
 
 
 if __name__ == '__main__':

--- a/pyod/test/test_small_n.py
+++ b/pyod/test/test_small_n.py
@@ -49,6 +49,14 @@ class TestSmallN(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.clf.compute_rejection_stats()
 
+    def test_unify_proba_no_nan_on_degenerate_reference(self):
+        X_degenerate = np.array([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]])
+        clf = SmallN(contamination=0.3)
+        clf.fit(X_degenerate)
+        probs = clf.predict_proba(
+            np.array([[1.0, 2.0], [100.0, 100.0]]), method='unify')
+        assert not np.isnan(probs).any()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyod/test/test_small_n.py
+++ b/pyod/test/test_small_n.py
@@ -58,5 +58,26 @@ class TestSmallN(unittest.TestCase):
         assert not np.isnan(probs).any()
 
 
+class TestSmallNRouting(unittest.TestCase):
+    """Covers ADEngine routing behavior specific to SmallN, not just the
+    detector class in isolation.
+    """
+
+    def test_tiny_low_dim_routes_to_small_n(self):
+        from pyod.utils.ad_engine import ADEngine
+        X = np.array([[1.0, 2.1], [1.1, 1.9], [0.9, 2.0]])
+        result = ADEngine().detect(X)
+        self.assertEqual(result['plan']['detector_name'], 'SmallN')
+        alt_names = [a['detector_name']
+                     for a in result['plan']['alternatives']]
+        self.assertNotIn('KNN', alt_names)
+
+    def test_tiny_high_dim_does_not_route_to_small_n(self):
+        from pyod.utils.ad_engine import ADEngine
+        X = np.random.RandomState(0).randn(4, 2000)
+        result = ADEngine().detect(X)
+        self.assertNotEqual(result['plan']['detector_name'], 'SmallN')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyod/test/test_small_n.py
+++ b/pyod/test/test_small_n.py
@@ -1,0 +1,38 @@
+"""Tests for pyod.models.small_n.SmallN.
+"""
+
+import unittest
+
+import numpy as np
+from numpy.testing import assert_equal
+
+from pyod.models.small_n import SmallN
+
+
+class TestSmallN(unittest.TestCase):
+    def setUp(self):
+        self.X_train = np.array([[1.0, 2.1], [1.1, 1.9], [0.9, 2.0]])
+        self.X_test = np.array([[1.0, 2.0], [8.0, 8.0]])
+        self.clf = SmallN(contamination=0.3)
+        self.clf.fit(self.X_train)
+
+    def test_fit(self):
+        assert hasattr(self.clf, 'decision_scores_')
+        assert_equal(len(self.clf.decision_scores_), len(self.X_train))
+
+    def test_decision_function_shape(self):
+        scores = self.clf.decision_function(self.X_test)
+        assert_equal(len(scores), len(self.X_test))
+
+    def test_outlier_scores_higher(self):
+        scores = self.clf.decision_function(self.X_test)
+        assert scores[1] > scores[0]
+
+    def test_predict_labels(self):
+        labels = self.clf.predict(self.X_test)
+        assert_equal(len(labels), len(self.X_test))
+        assert set(labels.tolist()).issubset({0, 1})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyod/utils/knowledge/algorithms.json
+++ b/pyod/utils/knowledge/algorithms.json
@@ -1551,5 +1551,32 @@
     "preprocessing_mode": "external",
     "requires": ["torch_geometric"],
     "version_added": "2.2.0"
-  }
+  },
+  "SmallN": {
+    "class_path": "pyod.models.small_n.SmallN",
+    "full_name": "Small-N Mahalanobis Distance (Ledoit-Wolf Shrinkage)",
+    "status": "shipped",
+    "data_types": ["tabular"],
+    "category": "linear",
+    "complexity": {"time": "O(n * d^2)", "space": "O(d^2)"},
+    "strengths": [
+      "Stable Mahalanobis distance estimation down to n=3 reference samples",
+      "Ledoit-Wolf shrinkage avoids singular covariance at low n",
+      "Simple, interpretable distance-based scoring"
+    ],
+    "weaknesses": [
+      "Assumes reference data is roughly unimodal",
+      "Rejection statistics (predict_with_rejection) are not supported for very small n with low contamination",
+      "Not designed for high-dimensional data relative to n"
+    ],
+    "best_for": "Small trusted reference sets, calibration runs, per-unit baselines, or pilot batches with only a handful of known-good observations",
+    "avoid_when": "Large reference sets are available, standard MCD or covariance-based detectors are more appropriate",
+    "benchmark_refs": [],
+    "benchmark_rank": {},
+    "paper": {"id": "ledoit_wolf_2004", "short": "Ledoit and Wolf, 2004"},
+    "default_params": {"contamination": 0.1},
+    "preprocessing_mode": "external",
+    "requires": [],
+    "version_added": "unreleased"
+  } 
 }

--- a/pyod/utils/knowledge/routing_rules.json
+++ b/pyod/utils/knowledge/routing_rules.json
@@ -36,7 +36,8 @@
       "conditions": [
         {"field": "data_type", "op": "eq", "value": "tabular"},
         {"field": "n_features", "op": "lt", "value": 20},
-        {"field": "n_samples", "op": "lt", "value": 5000}
+        {"field": "n_samples", "op": "lt", "value": 5000},
+        {"field": "n_samples", "op": "gte", "value": 10}
       ],
       "recommendations": [
         {"detector": "KNN", "params": {}, "confidence": 0.85},
@@ -65,18 +66,20 @@
       "id": "tabular_tiny_n",
       "conditions": [
         {"field": "data_type", "op": "eq", "value": "tabular"},
-        {"field": "n_samples", "op": "lt", "value": 10}
+        {"field": "n_samples", "op": "lt", "value": 10},
+        {"field": "n_features", "op": "lt", "value": 20}
       ],
       "recommendations": [
         {"detector": "SmallN", "params": {}, "confidence": 0.92}
       ],
-      "reason": "Tiny reference set (n<10): Ledoit-Wolf shrinkage covariance estimation",
+      "reason": "Tiny reference set (n<10, d<20): Ledoit-Wolf shrinkage covariance estimation",
       "evidence": ["Ledoit and Wolf, 2004"]
     },
     {
       "id": "tabular_balanced",
       "conditions": [
-        {"field": "data_type", "op": "eq", "value": "tabular"}
+        {"field": "data_type", "op": "eq", "value": "tabular"},
+        {"field": "n_samples", "op": "gte", "value": 10}
       ],
       "recommendations": [
         {"detector": "IForest", "params": {}, "confidence": 0.85},

--- a/pyod/utils/knowledge/routing_rules.json
+++ b/pyod/utils/knowledge/routing_rules.json
@@ -62,6 +62,18 @@
       "evidence": ["ADBench"]
     },
     {
+      "id": "tabular_tiny_n",
+      "conditions": [
+        {"field": "data_type", "op": "eq", "value": "tabular"},
+        {"field": "n_samples", "op": "lt", "value": 10}
+      ],
+      "recommendations": [
+        {"detector": "SmallN", "params": {}, "confidence": 0.92}
+      ],
+      "reason": "Tiny reference set (n<10): Ledoit-Wolf shrinkage covariance estimation",
+      "evidence": ["Ledoit and Wolf, 2004"]
+    },
+    {
       "id": "tabular_balanced",
       "conditions": [
         {"field": "data_type", "op": "eq", "value": "tabular"}


### PR DESCRIPTION
PyOD's existing MCD detector uses Minimum Covariance Determinant, which assumes a reasonably large n to estimate covariance robustly and isn't designed for very small reference sets. This adds a detector using Ledoit-Wolf shrinkage instead, which stays stable down to n=3 by adapting its regularisation to the sample size to feature ratio. Useful for cases like per-unit calibration runs or small pilot batches where only a handful of trusted reference points exist.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you created a <NewModel>.py in ~/pyod/models/?
* [x]  Have you created a <NewModel>_example.py in ~/examples/?
* [x] Have you created a test_<NewModel>.py in ~/pyod/test/?
* [x] Have you lint your code locally prior to submission?