### PR TITLE
clarify ECOD/COPOD relationship in docstrings (#655)

### DIFF
--- a/pyod/models/copod.py
+++ b/pyod/models/copod.py
@@ -50,10 +50,18 @@ def _parallel_ecdf(n_dims, X):
 
 
 class COPOD(BaseDetector):
-    """COPOD class for Copula Based Outlier Detector.
-    COPOD is a parameter-free, highly interpretable outlier detection algorithm
+    """COPOD is a parameter-free, highly interpretable outlier detection algorithm
     based on empirical copula models.
     See :cite:`li2020copod` for details.
+
+    .. note::
+        COPOD and :class:`~pyod.models.ecod.ECOD` are closely related: ECOD is
+        an extended, renamed formulation of COPOD, developed by the same
+        authors with a more refined mathematical presentation (see the
+        discussion in `GitHub issue #655
+        <https://github.com/yzhao062/pyod/issues/655>`_). We generally
+        recommend using ECOD, which is better documented and explained.
+        COPOD is retained for backward compatibility and availability.
 
     Parameters
     ----------

--- a/pyod/models/ecod.py
+++ b/pyod/models/ecod.py
@@ -51,11 +51,19 @@ def _parallel_ecdf(n_dims, X):
 
 
 class ECOD(BaseDetector):
-    """ECOD class for Unsupervised Outlier Detection Using Empirical
-    Cumulative Distribution Functions (ECOD)
-    ECOD is a parameter-free, highly interpretable outlier detection algorithm
+    """ECOD is a parameter-free, highly interpretable outlier detection algorithm
     based on empirical CDF functions.
     See :cite:`li2021ecod` for details.
+
+    .. note::
+        ECOD is an extended, renamed version of :class:`~pyod.models.copod.COPOD`,
+        developed by the same authors with a more refined presentation (see
+        the discussion in `GitHub issue #655
+        <https://github.com/yzhao062/pyod/issues/655>`_). ECOD is the
+        recommended choice of the two; COPOD is kept in the library mainly
+        for availability and backward compatibility.
+
+    
 
     Parameters
     ----------


### PR DESCRIPTION
### Summary

Adds a `.. note::` to both `COPOD` and `ECOD` class docstrings clarifying their relationship, as requested in #655.

### Context

Per @yzhao062's comment in #655, ECOD is an extended, renamed formulation of COPOD by the same authors, with a more refined mathematical presentation. Both are kept in the library — ECOD is recommended, COPOD is retained for availability/backward compatibility. This wasn't previously documented anywhere for users encountering both classes, so this PR adds a short cross-referencing note to each docstring pointing to the other and linking the GitHub discussion.

### Changes

- `pyod/models/copod.py`: added a note pointing to ECOD as the recommended choice
- `pyod/models/ecod.py`: added the mirrored note pointing back to COPOD

### Checklist

- [x] Followed the contributing guidelines
- [x] Checked there are no other open PRs for the same change
- [x] Tied this PR to issue #655
- [x] N/A — no code logic changed, no new tests needed (docs-only change)

Fixes #655