### PR TITLE
fix: support cosine distance in KNN

### DIFF
--- a/pyod/models/knn.py
+++ b/pyod/models/knn.py
@@ -8,7 +8,6 @@
 from warnings import warn
 
 import numpy as np
-from sklearn.neighbors import BallTree
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
@@ -189,20 +188,13 @@ class KNN(BaseDetector):
 
         self.neigh_.fit(X)
 
-        # In certain cases, _tree does not exist for NearestNeighbors
-        # See Issue #158 (https://github.com/yzhao062/pyod/issues/158)
-        # n_neighbors = 100
+        # Brute-force backends do not expose an internal tree. Reuse the
+        # fitted estimator in that case instead of rebuilding a BallTree,
+        # which rejects otherwise supported metrics such as cosine.
         if self.neigh_._tree is not None:
             self.tree_ = self.neigh_._tree
-
         else:
-            if self.metric_params is not None:
-                self.tree_ = BallTree(X, leaf_size=self.leaf_size,
-                                      metric=self.metric,
-                                      **self.metric_params)
-            else:
-                self.tree_ = BallTree(X, leaf_size=self.leaf_size,
-                                      metric=self.metric)
+            self.tree_ = self.neigh_
 
         dist_arr, _ = self.neigh_.kneighbors(n_neighbors=self.n_neighbors,
                                              return_distance=True)

--- a/pyod/test/test_knn.py
+++ b/pyod/test/test_knn.py
@@ -15,6 +15,7 @@ from numpy.testing import assert_raises
 from scipy.stats import rankdata
 from sklearn.base import clone
 from sklearn.metrics import roc_auc_score
+from sklearn.neighbors import NearestNeighbors
 
 # temporary solution for relative imports in case pyod is not installed
 # if pyod is installed, no need to use the following line
@@ -371,6 +372,28 @@ class TestKnnNearestNeighborsConfig(unittest.TestCase):
             mocked_kneighbors.assert_called_once()
 
         assert_equal(scores.shape[0], self.X_test.shape[0])
+
+    def test_cosine_metric_uses_brute_backend(self):
+        X_train = np.array([
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [1.0, -1.0],
+        ])
+        X_test = np.array([[2.0, 1.0], [-1.0, 1.0]])
+
+        clf = KNN(n_neighbors=2, metric='cosine')
+        clf.fit(X_train)
+
+        reference = NearestNeighbors(
+            n_neighbors=2, algorithm='auto', metric='cosine')
+        reference.fit(X_train)
+        train_distances, _ = reference.kneighbors(n_neighbors=2)
+        test_distances, _ = reference.kneighbors(X_test, n_neighbors=2)
+
+        assert_allclose(clf.decision_scores_, train_distances[:, -1])
+        assert_allclose(clf.decision_function(X_test),
+                        test_distances[:, -1])
 
 
 class TestKNNKwargsRejection(unittest.TestCase):


### PR DESCRIPTION
## Summary

Reuse the fitted `NearestNeighbors` estimator when scikit-learn selects a brute-force backend instead of rebuilding a `BallTree`. This lets KNN use metrics such as cosine that `NearestNeighbors` supports but `BallTree` rejects.

The regression test compares both training and inference scores with a scikit-learn `NearestNeighbors(metric="cosine")` reference.

Fixes #221.

## Root cause

`NearestNeighbors` correctly selects and fits its brute-force backend for cosine distance, leaving its private `_tree` attribute as `None`. PyOD treated that missing tree as a failure and constructed a new `BallTree` with the same metric, which raised `ValueError: Unrecognized metric 'cosine'`.

## Verification

- Regression test: failed before the fix with the reported `ValueError`; passes after the fix.
- `python -m pytest pyod/test/test_knn.py -v`: 44 passed.
- Coverage from the project-wide run: `pyod/models/knn.py` 100%, `pyod/test/test_knn.py` 99%.
- `python -m build`: sdist and wheel built successfully.
- `python -m twine check dist/*`: both distributions passed.

I also ran the complete project suite locally: 1,201 tests passed and 19 unrelated tests failed. Rerunning those exact 19 nodes on an unchanged `development` worktree produced the same failures: 18 require the optional PyTorch dependency omitted by the macOS workflow, and one detects an existing `claude` executable on this host. All 44 KNN tests pass.

### All Submissions Basics:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [x] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

<!-- The New Model Submissions section is omitted because this change fixes an existing model. -->
