### PR TITLE
Forward n_components in PyODKernelPCA

### DIFF
--- a/pyod/models/kpca.py
+++ b/pyod/models/kpca.py
@@ -35,6 +35,7 @@ class PyODKernelPCA(KernelPCA):
             random_state=None,
     ):
         super().__init__(
+            n_components=n_components,
             kernel=kernel,
             gamma=gamma,
             degree=degree,

--- a/pyod/test/test_kpca.py
+++ b/pyod/test/test_kpca.py
@@ -210,6 +210,12 @@ class TestKPCAComponentsBound(unittest.TestCase):
             n_components=10, n_selected_components=0, random_state=42
         )
 
+    def test_n_components_is_forwarded(self):
+        clf = KPCA(n_components=5, random_state=42)
+        clf.fit(self.X_train)
+        assert clf.kpca.n_components == 5
+        assert clf.kpca.eigenvectors_.shape[1] == 5
+
     def test_bound(self):
         self.clf.fit(self.X_train)
         with assert_raises(ValueError):


### PR DESCRIPTION
`PyODKernelPCA.__init__` accepts `n_components` but never passes it to `super().__init__()`:

```python
def __init__(self, n_components=None, kernel="rbf", gamma=None, ...):
    super().__init__(
        kernel=kernel,
        gamma=gamma,
        ...
    )
```

It is the only one of the sixteen parameters that is not forwarded, so the inner `KernelPCA` keeps its default of `None`. `KPCA` documents and exposes the argument, so asking for a few components silently computes all of them:

```python
clf = KPCA(n_components=3, random_state=0).fit(X)   # X is (420, 8)
```

On `master`:

```
inner PyODKernelPCA.n_components : None
components actually computed     : 419
transform(X).shape               : (420, 419)
```

With this PR:

```
inner PyODKernelPCA.n_components : 3
components actually computed     : 3
transform(X).shape               : (420, 3)
```

**The anomaly scores do not change.** `decision_function` slices `x_transformed[:, :n_selected_components_]` afterwards, so the surplus components never reach the score. I compared `decision_scores_` before and after across seven configurations — `n_components` of 1, 3 and 100, with `n_selected_components`, with `eigen_solver="arpack"`, with `remove_zero_eig=True`, with `kernel="linear"`, and with defaults — and the largest difference anywhere was `6.9e-14`.

What it costs today is time and memory, because with the inner value left at `None` sklearn always takes the dense `eigh` path:

| | `master` | this PR |
|---|---|---|
| fit, n=2000, `n_components=3` | 8.60 s | 0.50 s |
| transform matrix | 2000 x 1999 (32.0 MB) | 2000 x 3 |

`remove_zero_eig=False` is also ineffective at present, since sklearn forces zero-eigenvalue removal whenever `n_components is None`; forwarding the value restores that too.

Added `test_n_components_is_forwarded`. The existing tests pass `n_components` only for the validation cases, so nothing currently checks that it takes effect. It fails on `master` and passes here; `pyod/test/test_kpca.py` goes 17 -> 18 passing.
