### PR TITLE
Iterate over rows in the unweighted branch of pearsonr_mat

### DIFF
--- a/pyod/test/test_stat_models.py
+++ b/pyod/test/test_stat_models.py
@@ -17,6 +17,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from pyod.utils.stat_models import pairwise_distances_no_broadcast
 from pyod.utils.stat_models import wpearsonr
+from scipy.stats import pearsonr
 from pyod.utils.stat_models import pearsonr_mat
 from pyod.utils.stat_models import column_ecdf
 import statsmodels.distributions
@@ -62,6 +63,18 @@ class TestStatModels(unittest.TestCase):
 
         pear_mat = pearsonr_mat(self.mat, self.w_mat)
         assert_equal(pear_mat.shape, (10, 10))
+
+    def test_pearsonr_mat_fewer_features_than_samples(self):
+        # Every pair of rows must be correlated, including when the matrix has
+        # fewer columns than rows.
+        mat = np.random.rand(8, 3)
+        pear_mat = pearsonr_mat(mat)
+
+        assert_equal(pear_mat.shape, (8, 8))
+        for i in range(8):
+            for j in range(8):
+                expected = 1.0 if i == j else pearsonr(mat[i, :], mat[j, :])[0]
+                assert_allclose(pear_mat[i, j], expected)
 
         assert (np.min(pear_mat) >= -1)
         assert (np.max(pear_mat) <= 1)

--- a/pyod/utils/stat_models.py
+++ b/pyod/utils/stat_models.py
@@ -166,7 +166,6 @@ def pearsonr_mat(mat, w=None):
     """
     mat = check_array(mat)
     n_row = mat.shape[0]
-    n_col = mat.shape[1]
     pear_mat = np.full([n_row, n_row], 1).astype(float)
 
     if w is not None:
@@ -176,7 +175,7 @@ def pearsonr_mat(mat, w=None):
                 pear_mat[cx, cy] = curr_pear
                 pear_mat[cy, cx] = curr_pear
     else:
-        for cx in range(n_col):
+        for cx in range(n_row):
             for cy in range(cx + 1, n_row):
                 curr_pear = pearsonr(mat[cx, :], mat[cy, :])[0]
                 pear_mat[cx, cy] = curr_pear


### PR DESCRIPTION
`pearsonr_mat` builds an `(n_row, n_row)` matrix and fills it pairwise, but the two branches disagree on what to iterate over:

```python
n_row = mat.shape[0]
n_col = mat.shape[1]
pear_mat = np.full([n_row, n_row], 1).astype(float)

if w is not None:
    for cx in range(n_row):
        ...
else:
    for cx in range(n_col):
```

The weighted branch uses `n_row`, and the docstring describes the result as a "Row-wise pearson score matrix" of shape `(n_samples, n_samples)`.

So when a matrix has fewer columns than rows — the ordinary case — every pair with `cx >= n_col` is skipped, and those cells keep the `1` the matrix was initialised with. The function then reports a correlation of exactly `1.0` for pairs it never looked at.

Against `scipy.stats.pearsonr` as ground truth:

```
shape=(8, 3)     wrong cells =   20/64     max abs err = 1.952326
shape=(10, 5)    wrong cells =   20/100    max abs err = 1.753352
shape=(50, 4)    wrong cells = 2070/2500   max abs err = 1.998527
shape=(10, 20)   wrong cells =    0/100    max abs err = 0.000000
shape=(10, 10)   wrong cells =    0/100    max abs err = 0.000000
```

With this change every one of those shapes matches scipy exactly.

Scope:

- Output is unchanged whenever `n_col >= n_row - 1`; I checked 10x20, 10x12, 10x10 and 10x9 and they are identical before and after.
- The weighted branch is untouched — identical output for every shape tested, with and without `w`.
- The values that do change were never computed in the first place; they were the initialiser showing through.
- `n_col` has no remaining reader once the loop is corrected, so it goes with it.

The existing `test_pearsonr_mat` uses a `(10, 20)` matrix, which is in the unaffected range, and asserts only the shape — which is why this went unnoticed. The added test compares every entry against `scipy.stats.pearsonr` on an `(8, 3)` matrix; it fails on `master` and passes here. `pyod/test/test_stat_models.py` goes 5 -> 6 passing.

One note on reach: no detector in `pyod/models/` calls `pearsonr_mat` today — `lscp.py` imports plain `pearsonr` — so this affects direct users of the utility rather than the detector paths. It is exported in `pyod.utils.__all__` and documented, so it is public API.
