### PR TITLE
Stop Sampling.fit from overwriting subset_size

### DIFF
--- a/pyod/models/sampling.py
+++ b/pyod/models/sampling.py
@@ -140,13 +140,18 @@ class Sampling(BaseDetector):
             )
         if isinstance(self.subset_size, float) is True:
             if 0.0 < self.subset_size <= 1.0:
-                self.subset_size = int(self.subset_size * n_samples)
+                subset_size = int(self.subset_size * n_samples)
             else:
-                raise ValueError("subset_size=%r must be between 0.0 and 1.0")
+                raise ValueError(
+                    "subset_size=%r must be between 0.0 and 1.0"
+                    % self.subset_size
+                )
+        else:
+            subset_size = self.subset_size
 
         random_indices = self.random_state.choice(
             n_samples,
-            size=self.subset_size,
+            size=subset_size,
             replace=False,
         )
         self.subset = X[random_indices, :]

--- a/pyod/test/test_sampling.py
+++ b/pyod/test/test_sampling.py
@@ -190,6 +190,39 @@ class TestSamplingSubsetBound(unittest.TestCase):
         with assert_raises(ValueError):
             self.clf_int_lower.fit(self.X_train)
 
+    def test_fractional_subset_size_not_mutated(self):
+        # fit() used to overwrite self.subset_size with the absolute count,
+        # so a refit on a differently sized dataset reused the stale value
+        # and get_params() stopped returning what the user passed.
+        clf = Sampling(
+            subset_size=0.2, contamination=self.contamination, random_state=42
+        )
+
+        clf.fit(self.X_train)
+        assert_equal(clf.get_params()["subset_size"], 0.2)
+        assert_equal(len(clf.subset), int(0.2 * len(self.X_train)))
+
+        bigger = np.repeat(self.X_train, 2, axis=0)
+        clf.fit(bigger)
+        assert_equal(clf.get_params()["subset_size"], 0.2)
+        assert_equal(len(clf.subset), int(0.2 * len(bigger)))
+
+    def test_integer_subset_size_not_mutated(self):
+        clf = Sampling(
+            subset_size=25, contamination=self.contamination, random_state=42
+        )
+        clf.fit(self.X_train)
+        assert_equal(clf.get_params()["subset_size"], 25)
+        assert_equal(len(clf.subset), 25)
+
+    def test_invalid_fractional_subset_size_reports_the_value(self):
+        # the message used to contain a literal "%r" - the value was never
+        # interpolated into it.
+        clf = Sampling(subset_size=1.5, contamination=self.contamination)
+        with self.assertRaises(ValueError) as ctx:
+            clf.fit(self.X_train)
+        assert "1.5" in str(ctx.exception)
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
### What this fixes

`Sampling.fit` resolves a fractional `subset_size` by writing the absolute count back onto the estimator:

```python
if isinstance(self.subset_size, float) is True:
    if 0.0 < self.subset_size <= 1.0:
        self.subset_size = int(self.subset_size * n_samples)
```

so the constructor argument is destroyed by the first `fit`.

**1. A refit on differently sized data uses the stale count.**

```python
s = Sampling(subset_size=0.2, random_state=42)
s.fit(X100)     # 100 rows -> subset_size becomes 20   (correct: 20% of 100)
s.fit(X400)     # 400 rows -> still 20, not 80
```

| | before | after |
|---|---|---|
| `subset_size` after first fit | `20` | `0.2` |
| rows sampled on refit with 400 rows | `20` | `80` |
| `get_params()["subset_size"]` | `20` | `0.2` |

**2. It breaks the sklearn parameter contract.** `get_params()` no longer returns what was passed, so a `clone()` taken after a fit is not the estimator the user configured — which matters for anything that clones, such as `GridSearchCV` over `subset_size`.

The resolved value is now a local variable and `self.subset_size` is left untouched.

### One drive-by in the same lines

The `ValueError` for an out-of-range fraction was missing its `%` operand:

```python
raise ValueError("subset_size=%r must be between 0.0 and 1.0")
```

so it reported a literal `%r` instead of the offending value. Since I was restructuring these exact lines I fixed it rather than leaving it mid-rewrite; the integer branch immediately above already interpolates correctly. Happy to split it out if you'd prefer.

### Testing

Added three tests to the existing `TestSamplingSubsetBound` class:

- `test_fractional_subset_size_not_mutated` — asserts `get_params()` still returns `0.2` after a fit, and that a refit on a 2x larger dataset samples twice as many rows.
- `test_integer_subset_size_not_mutated` — an integer `subset_size` still round-trips and is used as-is.
- `test_invalid_fractional_subset_size_reports_the_value` — the error message contains `1.5`, not `%r`.

Without the change, two of these fail (`assert '1.5' in 'subset_size=%r must be between 0.0 and 1.0'` and the refit count). With it, `pyod/test/test_sampling.py` gives 22 passed.

`flake8` reports nothing new on either file — the remaining `E501` in `sampling.py` and `F841` in the test module are both present on an unmodified checkout.
