### PR TITLE
Keep logvar_clip as given so VAE can be cloned

### DIFF
--- a/pyod/models/vae.py
+++ b/pyod/models/vae.py
@@ -251,9 +251,14 @@ class VAE(BaseDeepLearningDetector):
         self.output_activation_name = output_activation_name
         self.batch_norm = batch_norm
         self.dropout_rate = dropout_rate
-        self.logvar_clip = self._validate_logvar_clip(logvar_clip)
+        # Validate eagerly, but keep the argument exactly as it was given:
+        # sklearn's clone() requires __init__ to store its parameters
+        # unmodified.
+        self._validate_logvar_clip(logvar_clip)
+        self.logvar_clip = logvar_clip
 
     def build_model(self):
+        self.logvar_clip_ = self._validate_logvar_clip(self.logvar_clip)
         self.model = VAEModel(self.feature_size,
                               encoder_neuron_list=self.encoder_neuron_list,
                               decoder_neuron_list=self.decoder_neuron_list,
@@ -262,7 +267,7 @@ class VAE(BaseDeepLearningDetector):
                               output_activation_name=self.output_activation_name,
                               batch_norm=self.batch_norm,
                               dropout_rate=self.dropout_rate,
-                              logvar_clip=self.logvar_clip)
+                              logvar_clip=self.logvar_clip_)
 
     def training_forward(self, batch_data):
         x = batch_data
@@ -271,7 +276,7 @@ class VAE(BaseDeepLearningDetector):
         x_recon, z_mu, z_logvar = self.model(x)
         loss = self.criterion(x, x_recon, z_mu, z_logvar,
                               beta=self.beta, capacity=self.capacity,
-                              logvar_clip=self.logvar_clip)
+                              logvar_clip=self.logvar_clip_)
         loss.backward()
         self.optimizer.step()
         return loss.item()

--- a/pyod/test/test_vae.py
+++ b/pyod/test/test_vae.py
@@ -8,6 +8,7 @@ import unittest
 import numpy as np
 
 # noinspection PyProtectedMember
+from sklearn.base import clone
 from sklearn.metrics import roc_auc_score
 
 # temporary solution for relative imports in case pyod is not installed
@@ -32,6 +33,26 @@ class TestVAEConfig(unittest.TestCase):
     def test_custom_logvar_clip(self):
         clf = VAE(epoch_num=1, logvar_clip=(-10, 5))
         self.assertEqual(clf.logvar_clip, (-10.0, 5.0))
+
+    def test_clone(self):
+        # __init__ used to store the validator's rebuilt tuple, so sklearn's
+        # identity check failed and VAE could not be used with any estimator
+        # that clones (GridSearchCV, cross_val_score, ...).
+        for logvar_clip in [(-30.0, 20.0), (-10, 5), None]:
+            clf = VAE(epoch_num=1, logvar_clip=logvar_clip)
+            cloned = clone(clf)
+            self.assertEqual(cloned.get_params()['logvar_clip'], logvar_clip)
+            self.assertIs(clf.get_params()['logvar_clip'], logvar_clip)
+
+    def test_logvar_clip_normalised_at_fit(self):
+        X = np.random.RandomState(42).randn(64, 5)
+        clf = VAE(epoch_num=1, logvar_clip=(-10, 5), contamination=0.1,
+                  verbose=0)
+        clf.fit(X)
+        # the argument is untouched, the normalised floats live on the
+        # trailing-underscore attribute
+        self.assertEqual(clf.logvar_clip, (-10, 5))
+        self.assertEqual(clf.logvar_clip_, (-10.0, 5.0))
 
     def test_invalid_logvar_clip(self):
         self.assertRaises(ValueError, VAE, epoch_num=1, logvar_clip=(1,))


### PR DESCRIPTION
### What this fixes

`VAE.__init__` stores the validator's return value instead of the argument it was given:

```python
self.logvar_clip = self._validate_logvar_clip(logvar_clip)
```

and `_validate_logvar_clip` ends with `return float(lower), float(upper)` — a freshly built tuple. sklearn's `clone()` verifies that a constructor leaves its parameters untouched using an identity comparison, so cloning a `VAE` fails outright:

```python
>>> from sklearn.base import clone
>>> clone(VAE())
RuntimeError: Cannot clone object VAE(...), as the constructor either does not
set or modifies parameter logvar_clip
```

This is a hard failure rather than a silent one: `VAE` cannot be used with anything that clones — `GridSearchCV`, `cross_val_score`, or a `Pipeline` being refit.

### The change

The argument is stored as given. Validation still runs in `__init__`, so an invalid `logvar_clip` is still rejected at construction time and `test_invalid_logvar_clip` is unaffected. The normalised floats move to `self.logvar_clip_`, derived in `build_model`, and that is what `VAEModel` and the training loss now read — so the numbers reaching the model are unchanged.

| | before | after |
|---|---|---|
| `clone(VAE())` | `RuntimeError` | works |
| `VAE(logvar_clip=(-10, 5)).logvar_clip` | `(-10.0, 5.0)` (rebuilt) | `(-10, 5)` (as given) |
| value used by the model | `(-10.0, 5.0)` | `(-10.0, 5.0)` via `logvar_clip_` |
| invalid clip | raises in `__init__` | raises in `__init__` |

### Testing

- `test_clone` — parametrised over `(-30.0, 20.0)`, `(-10, 5)` and `None`; asserts the clone round-trips and that `get_params()` returns the identical object. Fails on `master` with the `RuntimeError` above.
- `test_logvar_clip_normalised_at_fit` — the argument stays as passed while `logvar_clip_` holds the normalised floats after `fit`.
- `pyod/test/test_vae.py`: 21 passed.
- `flake8` reports the same 14 findings as on an unmodified checkout, none on the changed lines.

### Unrelated observation

While testing this I noticed `VAE.fit()` returns `None`, where the other detectors (e.g. `DeepSVDD`) return `self`, so `VAE().fit(X).predict(X)` doesn't work. That's present on `master` and independent of this change, so I've left it alone — happy to send it separately if you'd like.
