### PR TITLE
Return self from BaseDeepLearningDetector.fit

### DIFF
--- a/pyod/models/base_dl.py
+++ b/pyod/models/base_dl.py
@@ -174,6 +174,11 @@ class BaseDeepLearningDetector(BaseDetector):
 
         y : numpy array of shape (n_samples,), optional (default=None)
             The ground truth of input samples. Not used in unsupervised methods.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
         """
         # validate inputs X and y (optional)
         X = check_array(X)
@@ -201,6 +206,8 @@ class BaseDeepLearningDetector(BaseDetector):
 
         self.decision_scores_ = self.decision_function(X)
         self._process_decision_scores()
+
+        return self
 
     def training_prepare(self):
         self.model = self.model.to(self.device)

--- a/pyod/test/test_base_dl.py
+++ b/pyod/test/test_base_dl.py
@@ -170,6 +170,18 @@ class TestBaseDL(unittest.TestCase):
         # dummy_clf.fit(self.X_train)
         # self.assertEqual(dummy_clf.decision_scores_.all(), zero_scores.all())
 
+    def test_fit_returns_self(self):
+        # BaseDetector.fit documents "Returns: self : object", but the deep
+        # learning base returned None, so `clf.fit(X).predict(X)` raised
+        # AttributeError for every detector built on it.
+        dummy_clf = DummyDetector()
+        returned = dummy_clf.fit(self.X_train)
+
+        self.assertIs(returned, dummy_clf)
+        # the chained form users expect from an sklearn-style estimator
+        labels = DummyDetector().fit(self.X_train).predict(self.X_test)
+        self.assertEqual(labels.shape, (self.n_test,))
+
     def test_fit_with_y_is_ignored(self):
         zero_scores = np.zeros(self.n_train)
 


### PR DESCRIPTION
### What this fixes

`BaseDetector.fit` documents its contract as:

```
Returns
-------
self : object
```

but `BaseDeepLearningDetector.fit` ends on `self._process_decision_scores()` without returning, so every detector built on it returns `None`:

| detector | base | `fit()` returns |
|---|---|---|
| `VAE` | `BaseDeepLearningDetector` | **`None`** |
| `AutoEncoder` | `BaseDeepLearningDetector` | **`None`** |
| `DeepSVDD` | `BaseDetector` (own `fit`) | `DeepSVDD` |
| `IForest` | `BaseDetector` | `IForest` |

The practical effect is that the chained form these estimators otherwise support doesn't work:

```python
>>> VAE().fit(X).predict(X)
AttributeError: 'NoneType' object has no attribute 'predict'
```

and anything that relies on `fit` handing the estimator back — sklearn-style pipelines and helpers included — silently gets `None` instead.

### The change

One `return self` at the end of `fit`, plus the `Returns` section that the base class already documents. Nothing else in the call path changes, and no existing caller relied on the `None` (nothing in the package chains off `.fit(...)`).

### Testing

Added `test_fit_returns_self` to `TestBaseDL`, which uses the existing `DummyDetector` so it exercises the base class directly rather than one subclass. It asserts `fit` hands back the same object and that `DummyDetector().fit(X).predict(X)` produces labels of the right shape.

- without the change: `AssertionError: None is not DummyDetector(...)`
- with it: `pyod/test/test_base_dl.py`, `test_vae.py`, `test_auto_encoder.py` — 38 passed
- `flake8` reports the same 9 findings as an unmodified checkout, none on the changed lines

### Note

This touches `base_dl.py`, as does open PR #721 (save/load). I checked and there's no overlap — that PR doesn't touch `fit` — but flagging it in case you'd rather sequence them.
